### PR TITLE
Update lib/App/RecordStream/InputStream.pm

### DIFF
--- a/lib/App/RecordStream/InputStream.pm
+++ b/lib/App/RecordStream/InputStream.pm
@@ -78,10 +78,12 @@ use strict;
 use warnings;
 
 use IO::String;
-use JSON qw(decode_json);
+use JSON;
 
 use App::RecordStream::Record;
 require App::RecordStream::Operation;
+
+my $json = new JSON;
 
 my $ONE_OF = [qw(FH STRING FILE)];
 
@@ -209,7 +211,7 @@ sub get_record {
   }
 
   # Direct bless done in the name of performance
-  my $record = decode_json($line);
+  my $record = $json->decode($line);
   bless $record, 'App::RecordStream::Record';
 
   return $record;


### PR DESCRIPTION
Calling decode_json() expects the input string to be UTF8, otherwise this croaks.
By calling $obj->decode(), the parser only deals with octets in the input without
regard for their encoding (which may not be known and can be hard to determine).  This
supports arbitrary input data and leaves the problem of encoding up to
consumers.
