### PR TITLE
Fix input stream unicode handling

### DIFF
--- a/lib/App/RecordStream/Stream/Base.pm
+++ b/lib/App/RecordStream/Stream/Base.pm
@@ -1,9 +1,11 @@
 package App::RecordStream::Stream::Base;
 
-use JSON qw(decode_json);
+use JSON;
 
 use App::RecordStream::Record;
 use App::RecordStream::OutputStream;
+
+my $json = new JSON;
 
 sub new
 {
@@ -33,7 +35,7 @@ sub accept_line
   my $this = shift;
   my $line = shift;
 
-  my $record = App::RecordStream::Record->new(decode_json($line));
+  my $record = App::RecordStream::Record->new($json->decode($line));
 
   return $this->accept_record($record);
 }

--- a/tests/RecordStream/InputStream.t
+++ b/tests/RecordStream/InputStream.t
@@ -63,3 +63,12 @@ is_deeply($magic_stream->get_record(), undef, 'Magic input Ends');
 my $empty_fh = IO::String->new('');
 ok(my $empty_stream = App::RecordStream::InputStream->new(FH => $empty_fh), "Empty String Initialize");
 is_deeply($empty_stream->get_record(), undef, 'Empty String stream ends');
+
+{
+  my $key = "foo\x{263A}";  # \x{263A} - unicode white smiley
+  my $value = "bar\x{263A}";
+  my $handle = IO::String->new(qq({"$key":"$value"}));
+  my $stream = App::RecordStream::InputStream->new(FH => $handle);
+  is_deeply($stream->get_record(), { $key => $value },
+      'InputStream handles key+values with wide characters');
+}

--- a/tests/RecordStream/OptionalRequire.t
+++ b/tests/RecordStream/OptionalRequire.t
@@ -10,9 +10,10 @@ is($loaded, 0, 'Test nonexistant module load');
 $loaded = App::RecordStream::OptionalRequire::optional_use(qw(App::RecordStream::Operation));
 is($loaded, 1, 'Test existing module load');
 
-$loaded = App::RecordStream::OptionalRequire::optional_use(qw(JSON decode_json));
+$loaded = App::RecordStream::OptionalRequire::optional_use(qw(JSON));
 is($loaded, 1, 'Test external module with extra args');
 
-my $hash = decode_json('{"foo": "bar"}');
+my $json = new JSON;
+my $hash = $json->decode('{"foo": "bar"}');
 is($hash->{'foo'}, 'bar', "Test useing loaded method");
 

--- a/tests/RecordStream/OutputStream.t
+++ b/tests/RecordStream/OutputStream.t
@@ -8,11 +8,13 @@ use IO::String;
 use App::RecordStream::Record;
 use App::RecordStream::InputStream;
 
+my $unicode = "\x{263A}";  # \x{263A} - unicode white smiley
 my $rec = App::RecordStream::Record->new(
   'foo' => 'bar',
   'zoo' => {
     'blah' => 'biz',
     'far'  => [ 'fing', 'fang', 'foom' ],
+    "key-$unicode" => "value-$unicode",
   }
 );
 


### PR DESCRIPTION
- unit tests for key+value strings with unicode characters in them
- use $json->decode() instead of decode_json in
  App::RecordStream::Stream::Base
