### PR TITLE
lexically sort keys in tocsv, tohtml, and totable if no order is specifi...

### DIFF
--- a/lib/App/RecordStream/Operation/tocsv.pm
+++ b/lib/App/RecordStream/Operation/tocsv.pm
@@ -41,7 +41,7 @@ sub accept_record {
       $this->{'KEYS'} = $this->{'KEY_GROUPS'}->get_keyspecs($record);
     }
     else {
-      $this->{'KEYS'} = [keys %$record];
+      $this->{'KEYS'} = [sort keys %$record];
     }
 
     if ( $this->{'HEADERS'} ) {

--- a/lib/App/RecordStream/Operation/tohtml.pm
+++ b/lib/App/RecordStream/Operation/tohtml.pm
@@ -69,7 +69,7 @@ sub print_start {
     $this->{'FIELDS'} = $specs;
   }
   else {
-    $this->{'FIELDS'} = [keys %$record];
+    $this->{'FIELDS'} = [sort keys %$record];
   }
 
   return if ( $this->{'NO_HEADER'} );

--- a/lib/App/RecordStream/Operation/totable.pm
+++ b/lib/App/RecordStream/Operation/totable.pm
@@ -31,7 +31,7 @@ sub init {
   $this->parse_options($args, $spec);
 
   if ( ! $key_groups->has_any_group() ) {
-    $key_groups->add_groups('!.!returnrefs');
+    $key_groups->add_groups('!.!returnrefs!sort');
   }
 
   $this->{'NO_HEADER'}     = $no_header;

--- a/tests/RecordStream/Operation/tocsv.t
+++ b/tests/RecordStream/Operation/tocsv.t
@@ -32,7 +32,7 @@ App::RecordStream::Test::OperationHelper->test_output(
 
 App::RecordStream::Test::OperationHelper->test_output(
   'tocsv',
-  ['--key', '!oo!'],
+  ['--key', '!oo!sort'],
   $stream,
   $solution,
 );

--- a/tests/RecordStream/Operation/tohtml.t
+++ b/tests/RecordStream/Operation/tohtml.t
@@ -50,7 +50,7 @@ App::RecordStream::Test::OperationHelper->test_output(
 # KeyGroup test
 App::RecordStream::Test::OperationHelper->test_output(
   'tohtml',
-  ['--key', '!.!'],
+  ['--key', '!.!sort'],
   $stream,
   $solution,
 );

--- a/tests/RecordStream/Operation/totable.t
+++ b/tests/RecordStream/Operation/totable.t
@@ -30,7 +30,7 @@ App::RecordStream::Test::OperationHelper->test_output(
 
 App::RecordStream::Test::OperationHelper->test_output(
   'totable',
-  ['--key', '!oo!'],
+  ['--key', '!oo!sort'],
   $stream,
   $solution,
 );
@@ -62,7 +62,7 @@ SOLUTION
 
 App::RecordStream::Test::OperationHelper->test_output(
   'totable',
-  [qw(--k !foo!)],
+  [qw(--k !foo!sort)],
   $stream,
   $solution3,
 );


### PR DESCRIPTION
...ed

On perls with hash randomization (>= 5.18) this makes UTs pass and makes for a nicer user experience (columns don't randomly reorder themselves).  Not much of a departure from previous user facing behavior since the order was random (but consistent) before.  Low overhead since we only need to do one sort to get key order for the entire stream.

Also added sorts to the keyspecs as a quick way to get them passing again.

Out of the tests mentioned [here](https://rt.cpan.org/Public/Bug/Display.html?id=91452), only toptable is left (though I haven't yet run tests for all of the utilities requiring extra modules).
