### PR TITLE
Fix various --help-* options to recs-collate

### DIFF
--- a/lib/App/RecordStream/Operation/collate.pm
+++ b/lib/App/RecordStream/Operation/collate.pm
@@ -22,7 +22,7 @@ sub init {
   App::RecordStream::Aggregator->load_implementations();
 
   # clumping
-  my $clumper_options = App::RecordStream::Clumper::Options->new();
+  my $clumper_options = $this->{'CLUMPER_OPTIONS'} = App::RecordStream::Clumper::Options->new();
 
   # aggregation
   my @aggregators;
@@ -95,8 +95,6 @@ sub init {
   }
 
   $clumper_options->check_options(App::RecordStream::Operation::collate::BaseClumperCallback->new($aggregator_objects, $incremental, sub { $this->push_record($_[0]); }));
-
-  $this->{'CLUMPER_OPTIONS'} = $clumper_options;
 }
 
 sub build_dlaggregator {


### PR DESCRIPTION
Sets $this->{'CLUMPER_OPTIONS'} earlier in collate->init.

->parse_options, called in init between the changed hunks of this
commit, may call help option closures which call ->usage.  In turn,
->usage expects ->init to have already set $this->{'CLUMPER_OPTIONS'}.

The error displayed before this commit is:

```
Can't call method "main_usage" on an undefined value at
lib/App/RecordStream/Operation/collate.pm line 164.
```

and then the generic help (regardless of any specific help option
given).
