### PR TITLE
switch fromatomfeed from XML::Simple to XML::Twig

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -42,7 +42,6 @@ WriteMakefile(
      'Tie::Array'       => 0,
      'Tie::Hash'        => 0,
      'Tie::IxHash'      => 0,
-     'XML::Simple'      => 0,
      'XML::Twig'        => 0,
    },
 

--- a/todo/recs-fromatomfeed
+++ b/todo/recs-fromatomfeed
@@ -1,2 +1,0 @@
-switch from XML::Simple to XML::Twig to get streaming support (should be able to drop XML::Simple as a dependency
-afterwards)


### PR DESCRIPTION
Handles large documents
Drops XML::Simple as a dependency
