### PR TITLE
Mark todo and skip fromtcpdump tests

### DIFF
--- a/tests/RecordStream/Operation/fromtcpdump.t
+++ b/tests/RecordStream/Operation/fromtcpdump.t
@@ -31,9 +31,12 @@ my $solution = <<SOLUTION;
 {"dns":{"answer":[{"rdlength":4,"ttl":1800,"name":"blog.benjaminbernard.com","address":"63.251.171.81","class":"IN","type":"A","rdata":""},{"rdlength":4,"ttl":1800,"name":"blog.benjaminbernard.com","address":"69.25.27.170","class":"IN","type":"A","rdata":""},{"rdlength":4,"ttl":1800,"name":"blog.benjaminbernard.com","address":"63.251.171.80","class":"IN","type":"A","rdata":""},{"rdlength":4,"ttl":1800,"name":"blog.benjaminbernard.com","address":"69.25.27.173","class":"IN","type":"A","rdata":""},{"rdlength":4,"ttl":1800,"name":"blog.benjaminbernard.com","address":"66.150.161.141","class":"IN","type":"A","rdata":""},{"rdlength":4,"ttl":1800,"name":"blog.benjaminbernard.com","address":"66.150.161.140","class":"IN","type":"A","rdata":""}],"buffer":"","question":[{"qclass":"IN","qname":"blog.benjaminbernard.com","qtype":"A"}],"answersize":138,"additional":[],"authority":[],"header":{"nscount":0,"cd":0,"qdcount":1,"ancount":6,"rcode":"NOERROR","tc":0,"opcode":"QUERY","ad":0,"ra":1,"qr":1,"arcount":0,"id":3930,"aa":0,"rd":1},"offset":138},"ip":{"hlen":5,"len":166,"proto":17,"dest_ip":"10.0.2.15","flags":{},"foffset":0,"options":"","ttl":64,"ver":4,"cksum":23131,"src_ip":"10.0.0.1","tos":0,"id":2525},"file":"tests/files/test-capture1.pcap","caplen":180,"length":180,"timestamp":"1294004869.160748","ethernet":{"src_mac":"525400123500","dest_mac":"080027e0fd58"},"udp":{"len":146,"src_port":53,"dest_port":46578,"cksum":47199},"type":"udp"}
 SOLUTION
 
-App::RecordStream::Test::OperationHelper->do_match(
-  'fromtcpdump',
-  ['tests/files/test-capture1.pcap'],
-  '',
-  $solution,
-);
+TODO: {
+    todo_skip "Net::DNS::Packet (and contained classes) don't serialize properly yet";
+    App::RecordStream::Test::OperationHelper->do_match(
+      'fromtcpdump',
+      ['tests/files/test-capture1.pcap'],
+      '',
+      $solution,
+    );
+}


### PR DESCRIPTION
Net::DNS::Packet doesn't serialize properly yet.  JSON::XS is configured
to allow blessed objects and convert them if a TO_JSON method is
available.  If TO_JSON is not available, however, the object is replaced
by a JSON null.  Net::DNS::Packet doesn't have a TO_JSON method.
Monkey-patching one in will require futzing with a number of other
classes contained with Net::DNS::Packet objects too.

See GH #32.
