### PR TITLE
Text::CSV_XS 0.98 under Perl 5.18.1 causes test failures; require 0.99

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -38,7 +38,7 @@ WriteMakefile(
      'Test::More'       => 0,
      'Text::Autoformat' => 0,
      'Text::CSV'        => 0,
-     'Text::CSV_XS'     => 0,
+     'Text::CSV_XS'     => 0.99,
      'Tie::Array'       => 0,
      'Tie::Hash'        => 0,
      'Tie::IxHash'      => 0,


### PR DESCRIPTION
The most telling failure is in fromcsv.t, while parsing this:

```
foo,bar,baz
"foo
loo","bar loo", baz
```

resulting in:

```
Expected:
{"zip":["foo","bar","baz"]}
{"zip":["foo\nloo","bar loo","baz"]}
Output from module:
{"zip":["foo","bar","baz"]}
{"zip":["\"foo"]}
{"zip":["loo\"","bar loo","baz"]}
```

The same parsing bug caused failures in FilenameKey.t as well.
