### PR TITLE
Add new `fromjsonarray` operation.

### DIFF
--- a/bin/recs-fromjsonarray
+++ b/bin/recs-fromjsonarray
@@ -1,0 +1,1 @@
+recs-operation

--- a/lib/App/RecordStream/Operation/fromjsonarray.pm
+++ b/lib/App/RecordStream/Operation/fromjsonarray.pm
@@ -1,0 +1,105 @@
+package App::RecordStream::Operation::fromjsonarray;
+
+our $VERSION = "4.0.4";
+
+use strict;
+use warnings;
+
+use base qw(App::RecordStream::Operation);
+
+use App::RecordStream::Record;
+
+use JSON;
+
+sub init {
+  my ($this, $args) = @_;
+
+  my @fields;
+  my $preserve_empty = undef;
+
+  my $spec = {
+    'key|k=s'        => sub { push @fields, split(/,/, $_[1]); },
+    'preserve-empty' => \$preserve_empty,
+  };
+
+  $this->parse_options($args, $spec);
+
+  $this->{'EXTRA_ARGS'}     = $args;
+  $this->{'FIELDS'}         = \@fields;
+  $this->{'PRESERVE_EMPTY'} = $preserve_empty;
+  $this->{'JSON'}           = JSON->new();
+}
+
+sub wants_input {
+  return 0;
+}
+
+sub stream_done {
+  my ($this) = @_;
+
+  my $files = $this->{'EXTRA_ARGS'};
+
+  if ( scalar @$files > 0 ) {
+    foreach my $file ( @$files ) {
+      $this->update_current_filename($file);
+
+      open(my $fh, '<', $file) or die "Could not open file: $!\n";
+      $this->get_records_from_handle($fh);
+      close $fh;
+    }
+  }
+  else {
+    $this->get_records_from_handle(\*STDIN);
+  }
+}
+
+sub get_records_from_handle {
+  my ($this, $fh) = @_;
+
+  my $json = $this->{'JSON'};
+  my $fields = $this->{'FIELDS'};
+  my $has_fields = scalar @$fields;
+
+  local $/;
+  my $contents = <$fh>;
+
+  my $items = $json->decode($contents);
+
+  for my $item (@$items) {
+    my $record;
+
+    if ($has_fields) {
+      $record = App::RecordStream::Record->new();
+      for my $field (@$fields) {
+        $record->set($field, $item->{$field}) if exists $item->{$field};
+      }
+    }
+    else {
+      $record = App::RecordStream::Record->new($item);
+    }
+
+    $this->push_record($record)
+      if scalar $record->keys() || $this->{'PRESERVE_EMPTY'};
+  }
+}
+
+sub usage {
+  my ($this) = @_;
+
+  my $options = [
+    [ 'key|k <keys>', 'Optional Comma separated list of field names.  If none specified, use all keys.  May be specified multiple times, may be key specs' ],
+    [ 'preserve-empty', 'Enable output of empty records' ],
+  ];
+
+  my $args_string = $this->options_string($options);
+
+  return <<USAGE;
+Usage: recs-fromjsonarray <args> [<files>]
+   __FORMAT_TEXT__
+   Import JSON objects from within a JSON array.
+   __FORMAT_TEXT__
+Arguments:
+$args_string
+
+USAGE
+}

--- a/tests/RecordStream/Operation/fromjsonarray.t
+++ b/tests/RecordStream/Operation/fromjsonarray.t
@@ -1,0 +1,49 @@
+use Test::More qw(no_plan);
+
+use App::RecordStream::Test::Tester;
+
+BEGIN { use_ok( 'App::RecordStream::Operation::fromjsonarray' ) };
+
+my $tester = App::RecordStream::Test::Tester->new('fromjsonarray');
+
+my $input;
+my $output;
+
+$input1 = <<'INPUT';
+[{"a": 1, "foo": "bar"},{"b": 2, "a": 2},{"c": 3},{"b": 4}]
+INPUT
+
+$input2 = <<'INPUT';
+[
+  {
+    "a": 1,
+    "foo": "bar"
+  },
+  {"b": 2, "a": 2},
+  {"c": 3},
+  {"b": 4}
+]
+INPUT
+
+$output = <<'OUTPUT';
+{"a":1,"foo":"bar"}
+{"a":2,"b":2}
+{"c":3}
+{"b":4}
+OUTPUT
+$tester->test_stdin([], $input1, $output);
+$tester->test_stdin([], $input2, $output);
+
+$output = <<'OUTPUT';
+{"a":1}
+{"a":2}
+OUTPUT
+$tester->test_stdin(['--key', 'a'], $input1, $output);
+
+$output = <<'OUTPUT';
+{"a":1}
+{"a":2,"b":2}
+{}
+{"b":4}
+OUTPUT
+$tester->test_stdin(['--key', 'a,b', '--preserve-empty'], $input1, $output);


### PR DESCRIPTION
This allows importing records contained within JSON arrays.

I found this to be useful in combination with some of the other `recs-*` tools. The intent of this command for `recs-fromjson -k f1,f2,f3` is to work quite similar to how `jq -c '.[]|{"f1": .f1, "f2": .f2, "f3": .f3}'`

See http://stedolan.github.io/jq/ for details.

The usage says that it supports key specs, but I wasn't quite sure how to make that happen. I figure you could use this as a first draft of this feature if nothing else.
