### PR TITLE
recs-assert: Assert truths about your record streams

### DIFF
--- a/bin/recs-assert
+++ b/bin/recs-assert
@@ -1,0 +1,1 @@
+recs-operation

--- a/doc/recs-assert.pod
+++ b/doc/recs-assert.pod
@@ -1,0 +1,102 @@
+=head1 NAME
+
+recs-assert
+
+=head1 recs-assert --help-all
+
+ Help from: --help-basic:
+ Usage: recs-assert <args> <expr> [<files>]
+    Asserts that every record in the stream must pass the given <expr>.
+ 
+    <expr> is evaluated as Perl on each record of input (or records from <files>)
+    with $r set to a App::RecordStream::Record object and $line set to the
+    current line number (starting at 1). If <expr> does not evaluate to true,
+    processing is immediately aborted and an error message printed. See --help-
+    snippets for more information on code snippets.
+ 
+    --diagnostic|-d <text>       Include the diagnostic string <text> in any
+                                 failed assertion errors
+    --verbose|-v                 Verbose output for failed assertions; dumps the
+                                 current record
+    --e                          a perl snippet to execute, optional
+    --E                          the name of a file to read as a perl snippet
+    --M module[=...]             execute "use module..." before executing
+                                 snippet; same behaviour as perl -M
+    --m module[=...]             same as -M, but by default import nothing
+    --filename-key|fk <keyspec>  Add a key with the source filename (if no
+                                 filename is applicable will put NONE)
+ 
+   Help Options:
+       --help-all      Output all help for this script
+       --help          This help screen
+       --help-snippet  Help on code snippets
+ 
+ Examples:
+    Require each record to have a "date" field.
+       recs-assert '$r->{date}'
+ 
+ Help from: --help-snippet:
+    CODE SNIPPETS:
+     Recs code snippets are perl code, with one exception. There a couple of
+     variables predefined for you, and one piece of special syntax to assist in
+     modifying hashes.
+ 
+ Special Variables:
+     $r - the current record object. This may be used exactly like a hash, or you
+     can use some of the special record functions, see App::RecordStream::Record
+     for more information
+ 
+     $line - This is the number of records run through the code snippet, starting
+     at 1. For most scripts this corresponds to the line number of the input to
+     the script.
+ 
+     $filename - The filename of the originating record. Note: This is only
+     useful if you're passing filenames directly to the recs script, piping
+     from other recs scripts or from cat, for instance, will not have a
+     useful filename.
+ 
+ Special Syntax
+     Use {{search_string}} to look for a string in the keys of a record, use /
+     to nest keys. You can nest into arrays by using an index. If you are
+     vivifying arrays (if the array doesn't exist, prefix your key with # so
+     that an array rather than a hash will be created to put a / in your key,
+     escape it twice, i.e. \/
+ 
+     This is exactly the same as a key spec that is always prefaced with a @, see
+     'man recs' for more info on key specs
+ 
+     For example: A record that looks like:
+     { "foo" : { "bar 1" : 1 }, "zoo" : 2}
+     Could be accessed like this:
+ 
+     # value of zoo  # value of $r->{foo}->{bar 1}: (comma separate nested keys)
+     {{zoo}}         {{foo/ar 1}}
+ 
+     # Even assign to values (set the foo key to the value 1)
+     {{foo}} = 1
+ 
+     # And auto, vivify
+     {{new_key/array_key/#0}} = 3 # creates an array within a hash within a hash
+ 
+     # Index into an array
+     {{array_key/#3}} # The value of index 3 of the array ref under the
+     'array_key' hash key.
+ 
+     This matching is a fuzzy keyspec matching, see --help-keyspecs for
+     more details.
+ 
+
+=head1 See Also
+
+=over
+
+=item  L<RecordStream(3)> - Overview of the scripts and the system
+
+=item  L<recs-examples(3)> - A set of simple recs examples
+
+=item  L<recs-story(3)> - A humorous introduction to RecordStream
+
+=item SCRIPT --help - every script has a --help option, like the output above
+
+=back
+

--- a/lib/App/RecordStream/Operation/assert.pm
+++ b/lib/App/RecordStream/Operation/assert.pm
@@ -1,0 +1,91 @@
+package App::RecordStream::Operation::assert;
+
+our $VERSION = "4.0.4";
+
+use strict;
+use warnings;
+
+use base qw(App::RecordStream::Operation);
+
+use App::RecordStream::Executor::Getopt;
+use App::RecordStream::Executor;
+use Data::Dumper ();
+
+sub init {
+  my $this = shift;
+  my $args = shift;
+
+  $this->{DIAGNOSTIC} = '';
+  $this->{VERBOSE}    = 0;
+
+  my $executor_options = App::RecordStream::Executor::Getopt->new();
+  my $spec = {
+    'diagnostic|d=s' => \$this->{DIAGNOSTIC},
+    'verbose|v'      => \$this->{VERBOSE},
+    $executor_options->arguments(),
+  };
+
+  $this->parse_options($args, $spec, ['bundling']);
+
+  my $expression = $executor_options->get_string($args);
+  my $executor = App::RecordStream::Executor->new($expression);
+
+  $this->{'ASSERTION'} = $expression;
+  $this->{'EXECUTOR'}  = $executor;
+}
+
+sub accept_record {
+  my $this   = shift;
+  my $record = shift;
+
+  unless ($this->{'EXECUTOR'}->execute_code($record)) {
+    die "Assertion failed! $this->{DIAGNOSTIC}\n",
+        "Expression: « $this->{ASSERTION} »\n",
+        "Filename: ", $this->get_current_filename, "\n",
+        "Line: $.\n",
+        ($this->{VERBOSE}
+          ? ("Record: ", Data::Dumper->Dump([$record->as_hashref], ['r']), "\n")
+          : ());
+  }
+
+  $this->push_record($record);
+  return 1;
+}
+
+sub add_help_types {
+  my $this = shift;
+  $this->use_help_type('snippet');
+}
+
+sub usage {
+  my $this = shift;
+
+  my $options = [
+    ['diagnostic|-d <text>' => 'Include the diagnostic string <text> in any failed assertion errors'],
+    ['verbose|-v'           => 'Verbose output for failed assertions; dumps the current record'],
+    App::RecordStream::Executor::options_help(),
+  ];
+
+  my $args_string = $this->options_string($options);
+
+  my $usage =  <<USAGE;
+Usage: recs-assert <args> <expr> [<files>]
+   __FORMAT_TEXT__
+   Asserts that every record in the stream must pass the given <expr>.
+
+   <expr> is evaluated as Perl on each record of input (or records from
+   <files>) with \$r set to a App::RecordStream::Record object and \$line set
+   to the current line number (starting at 1).  If <expr> does not evaluate to
+   true, processing is immediately aborted and an error message printed.  See
+   --help-snippets for more information on code snippets.
+   __FORMAT_TEXT__
+
+$args_string
+
+Examples:
+   Require each record to have a "date" field.
+      recs-assert '\$r->{date}'
+USAGE
+}
+
+1;

--- a/tests/RecordStream/Operation/assert.t
+++ b/tests/RecordStream/Operation/assert.t
@@ -1,0 +1,63 @@
+use Test::More qw(no_plan);
+use App::RecordStream::Test::OperationHelper;
+
+use strict;
+use warnings;
+
+BEGIN { use_ok( 'App::RecordStream::Operation::assert' ) };
+
+my $stream = <<STREAM;
+{"foo":1,"zoo":"biz1","boo":"boo1"}
+{"foo":2,"zoo":null,"boo":"boo2"}
+{"foo":3,"zoo":"biz3","boo":"boo3"}
+STREAM
+
+my ($ok, $err);
+
+# Assertion held
+$ok = eval {
+  App::RecordStream::Test::OperationHelper->do_match(
+    'assert',
+    ['1'],
+    $stream,
+    $stream,
+  );
+  1;
+};
+$err = $@;
+ok $ok, 'True assertion passes through records';
+ok !$err, 'No error';
+
+# Assertion broken
+$ok = eval {
+  App::RecordStream::Test::OperationHelper->do_match(
+    'assert',
+    ['{{zoo}}'],
+    $stream,
+    '',
+  );
+  1;
+};
+$err = $@;
+ok !$ok, 'Failed assertion causes error';
+ok $err, 'Caught error';
+like $err, qr/\Q{{zoo}}\E/, 'Error contains expression';
+like $err, qr/Line:\s*2/i, 'Error contains line number';
+
+# Options
+$ok = eval {
+  App::RecordStream::Test::OperationHelper->do_match(
+    'assert',
+    [qw(-d ohhai -v {{zoo}})],
+    $stream,
+    '',
+  );
+  1;
+};
+$err = $@;
+ok !$ok, 'Failed assertion causes error';
+ok $err, 'Caught error';
+like $err, qr/\Q{{zoo}}\E/, 'Error contains expression';
+like $err, qr/Line:\s*2/i, 'Error contains line number';
+like $err, qr/ohhai/, 'Error contains diagnostic';
+like $err, qr/Record: \$r = \{.*?boo2/s, 'Error contains dumped record';


### PR DESCRIPTION
recs-assert provides a simple way to build sanity checking of your data
into your pipelines.  It is often useful after an xform or join
operation to check that certain assumptions hold true for every record.
