### PR TITLE
Perl 5.21.1 compat

### DIFF
--- a/lib/App/RecordStream/Executor.pm
+++ b/lib/App/RecordStream/Executor.pm
@@ -225,10 +225,10 @@ sub transform_code {
   my $this = shift;
   my $code = shift;
 
-  while ( $code =~ m/{{(.*?)}}/ ) {
+  while ( $code =~ m/\{\{(.*?)\}\}/ ) {
     my $specifier = $1;
     my $guessing_code = '${App::RecordStream::KeySpec::find_key($r, qq{\@' . $specifier . '})}';
-    $code =~ s/{{.*?}}/$guessing_code/;
+    $code =~ s/\{\{.*?\}\}/$guessing_code/;
   }
 
   return $code;


### PR DESCRIPTION
Fixes compilation errors and silences deprecation warnings introduced in Perl 5.21.1.

A small bug-fix is also included in related code.
