### PR TITLE
Extend site loading

### DIFF
--- a/META.json
+++ b/META.json
@@ -221,6 +221,7 @@
       },
       "test" : {
          "requires" : {
+            "File::Spec::Functions" : "0",
             "IPC::Open2" : "0",
             "Test::More" : "0.88"
          }

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -81,6 +81,7 @@ my %WriteMakefileArgs = (
     "Tie::Hash" => 0
   },
   "TEST_REQUIRES" => {
+    "File::Spec::Functions" => 0,
     "IPC::Open2" => 0,
     "Test::More" => "0.88"
   },
@@ -108,6 +109,7 @@ my %FallbackPrereqs = (
   "Date::Manip" => 0,
   "File::Basename" => 0,
   "File::Glob" => 0,
+  "File::Spec::Functions" => 0,
   "File::Temp" => 0,
   "FindBin" => 0,
   "Getopt::Long" => 0,

--- a/bin/recs
+++ b/bin/recs
@@ -87,6 +87,10 @@ sub version {
   print "recs/" . ($VERSION || $App::RecordStream::VERSION);
   print " (fatpacked)" if grep { ref =~ /^FatPacked/ } @INC;
   print "\n";
+  if (my @sites = App::RecordStream::Site::list_sites()) {
+    print "Loaded sites:\n";
+    print "  $_\n" for sort { $a cmp $b } map { $_->{name} } @sites;
+  }
   exit;
 }
 

--- a/bin/recs
+++ b/bin/recs
@@ -6,11 +6,14 @@ no warnings 'exec';
 our $VERSION;
 
 use App::RecordStream;
+use App::RecordStream::Site;
 use App::RecordStream::Operation;
 use File::Basename 'basename';
 use File::Glob 'bsd_glob';
 use Getopt::Long;
 use Module::Pluggable::Object;
+
+App::RecordStream::Site::bootstrap();
 
 Getopt::Long::Configure(qw( require_order pass_through ));
 GetOptions(

--- a/cpanfile
+++ b/cpanfile
@@ -30,6 +30,7 @@ on 'configure' => sub {
 
 on 'test' => sub {
     requires 'Test::More', '0.88';
+    requires 'File::Spec::Functions';
     requires 'IPC::Open2';
 };
 

--- a/dist.ini
+++ b/dist.ini
@@ -21,7 +21,7 @@ run = ./devel/fatpack-recs
 
 ; The following configuration is based on Dist::Zilla::PluginBundle::Milla.
 
-; The following two stanzas ensure the git repo is installable by copying over
+; The following stanzas ensure the git repo is installable by copying over
 ; installer-bits from the build and ignoring them when gathering files before
 ; the build.
 [Git::GatherDir]
@@ -33,6 +33,12 @@ exclude_filename = LEGAL
 exclude_filename = README.md
 exclude_filename = recs
 exclude_match    = ^(devel|local|fatlib)/
+
+; Explicitly include the following dotfile for tests, which is skipped by
+; Git::GatherDir above.
+[GatherDir]
+root = tests/files/.recs/
+prefix = tests/files/.recs/
 
 [PruneCruft]
 

--- a/tests/RecordStream/Site.t
+++ b/tests/RecordStream/Site.t
@@ -4,18 +4,54 @@ use Test::More;
 use File::Basename qw< dirname >;
 use File::Spec::Functions qw< catdir updir >;
 
+# Protect against any unexpected user config when running tests.
+undef $ENV{RECS_SITELIB};
+undef $ENV{HOME};
+
 my $testlib = catdir($ENV{BASE_TEST_DIR}, "lib");
 
 # Defaults
 {
   my $output = load_sites();
   unlike $output, qr/Recs::Site::INC/,        "not loaded INC.pm";
+  unlike $output, qr/Recs::Site::EnvSiteLib/, "not loaded EnvSiteLib.pm";
+  unlike $output, qr/Recs::Site::Home/,       "not loaded Home.pm";
 }
 
 # Defaults, local @INC
 {
   my $output = load_sites("-Mlib=$testlib");
   like   $output, qr/Recs::Site::INC/,        "    loaded INC.pm";
+  unlike $output, qr/Recs::Site::EnvSiteLib/, "not loaded EnvSiteLib.pm";
+  unlike $output, qr/Recs::Site::Home/,       "not loaded Home.pm";
+}
+
+# RECS_SITELIB
+{
+  local $ENV{RECS_SITELIB} = $testlib;
+  my $output = load_sites();
+  unlike $output, qr/Recs::Site::INC/,        "not loaded INC.pm";
+  like   $output, qr/Recs::Site::EnvSiteLib/, "    loaded EnvSiteLib.pm";
+  unlike $output, qr/Recs::Site::Home/,       "not loaded Home.pm";
+}
+
+# HOME
+{
+  local $ENV{HOME} = catdir($ENV{BASE_TEST_DIR}, "files");
+  my $output = load_sites();
+  unlike $output, qr/Recs::Site::INC/,        "not loaded INC.pm";
+  unlike $output, qr/Recs::Site::EnvSiteLib/, "not loaded EnvSiteLib.pm";
+  like   $output, qr/Recs::Site::Home/,       "    loaded Home.pm";
+}
+
+# All together now!
+{
+  local $ENV{HOME} = catdir($ENV{BASE_TEST_DIR}, "files");
+  local $ENV{RECS_SITELIB} = $testlib;
+  my $output = load_sites("-Mlib=$testlib");
+  like   $output, qr/Recs::Site::INC/,        "    loaded INC.pm";
+  like   $output, qr/Recs::Site::EnvSiteLib/, "    loaded EnvSiteLib.pm";
+  like   $output, qr/Recs::Site::Home/,       "    loaded Home.pm";
 }
 
 sub load_sites {

--- a/tests/RecordStream/Site.t
+++ b/tests/RecordStream/Site.t
@@ -1,0 +1,39 @@
+use strict;
+use warnings;
+use Test::More;
+use File::Basename qw< dirname >;
+use File::Spec::Functions qw< catdir updir >;
+
+my $testlib = catdir($ENV{BASE_TEST_DIR}, "lib");
+
+# Defaults
+{
+  my $output = load_sites();
+  unlike $output, qr/Recs::Site::INC/,        "not loaded INC.pm";
+}
+
+# Defaults, local @INC
+{
+  my $output = load_sites("-Mlib=$testlib");
+  like   $output, qr/Recs::Site::INC/,        "    loaded INC.pm";
+}
+
+sub load_sites {
+  # Use new processes to most robustly isolate repeated site loading
+  require App::RecordStream::Site;
+  my $ourlib = catdir(dirname($INC{"App/RecordStream/Site.pm"}), updir, updir);
+
+  # Respect test.pl's PERL5OPT setting but control the ordering of our own opts.
+  my @perl5opt = split ' ', $ENV{PERL5OPT} || "";
+  local $ENV{PERL5OPT};
+
+  open(my $pipe, '-|',
+    $^X, @perl5opt, "-Mlib=$ourlib", @_,
+    "-MApp::RecordStream::Site",
+    "-e", 'App::RecordStream::Site::bootstrap()')
+      or die "open pipe failed: $!";
+  local $/;
+  return scalar <$pipe>;
+}
+
+done_testing;

--- a/tests/files/.recs/site/Home.pm
+++ b/tests/files/.recs/site/Home.pm
@@ -1,0 +1,3 @@
+package Recs::Site::Home;
+print __PACKAGE__, "\n";
+1;

--- a/tests/lib/EnvSiteLib.pm
+++ b/tests/lib/EnvSiteLib.pm
@@ -1,0 +1,3 @@
+package Recs::Site::EnvSiteLib;
+print __PACKAGE__, "\n";
+1;

--- a/tests/lib/Recs/Site/INC.pm
+++ b/tests/lib/Recs/Site/INC.pm
@@ -1,0 +1,3 @@
+package Recs::Site::INC;
+print __PACKAGE__, "\n";
+1;


### PR DESCRIPTION
Adds two ways to load sites: from `~/.recs/site/` and from any `RECS_SITELIB` in the environment.  + tests and a bugfix for `recs --list-commands`.

This enables, for example, my plan to fatpack App::RecordStream::Bio for use with the fatpacked `recs`: https://github.com/MullinsLab/App-RecordStream-Bio/compare/fatpacked.  It also allows for simple per-user sites without needing to install to `@INC` or set `PERL5LIB`, which is nice.