### PR TITLE
[ContributorsFromGit] -> [Git::Contributors]

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -102,7 +102,7 @@ WriteMakefile_arg = MAN1PODS => { map { m{doc/(.+)\.pod$} ? ($_ => "\$(INST_MAN1
 WriteMakefile_arg = depend   => { map { ($_ => "generate_pods") } grep { -f and not /recs-operation/ } <doc/recs-*.pod> }
 WriteMakefile_arg = PL_FILES => { 'generate_pods.pl' => 'generate_pods' }
 
-[ContributorsFromGit]
+[Git::Contributors]
 
 [PodSyntaxTests]
 [MetaJSON]


### PR DESCRIPTION
This plugin has unresolved issues on MSWin32 and with handling unicode names, so I forked it last year.