### PR TITLE
move to RewriteVersion because it will install on newer Perls

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -49,7 +49,7 @@ copy = LICENSE
 copy = Makefile.PL
 
 ; Should stay after GatherDir
-[VersionFromModule]
+[RewriteVersion]
 [ReversionOnRelease]
 prompt = 1
 


### PR DESCRIPTION
Hi!

I received your module as part of this month's [CPAN PR-Challenge](http://cpan-prc.org/).  Making use of [RewriteVersion](https://metacpan.org/pod/Dist::Zilla::Plugin::RewriteVersion) gets rid of the following problem when trying to build on newer Perls with Dist::Zilla:

```
$ cpanm Dist::Zilla::Plugin::VersionFromModule
--> Working on Dist::Zilla::Plugin::VersionFromModule
Fetching http://www.cpan.org/authors/id/C/CJ/CJM/Dist-Zilla-Plugins-CJM-4.27.tar.gz ... OK
Configuring Dist-Zilla-Plugins-CJM-4.27 ... OK
Building and testing Dist-Zilla-Plugins-CJM-4.27 ... FAIL
! Installing Dist::Zilla::Plugin::VersionFromModule failed. See /Users/cwhitener/.cpanm/work/1473390305.53210/build.log for details. Retry with --force to force install it.
```

Thanks,
Chase