### PR TITLE
tojsonarray: Output the record stream as a single JSON array

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,7 @@
 {{$NEXT}}
+    [Features]
+        * tojsonarray: A new command for outputting the record stream as a
+          single JSON array.  Complements the existing fromjsonarray.
 
 4.0.22  2016-11-09 16:24:48 PST
     [Features]

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-This software is Copyright (c) 2010-2016 by the AUTHORS.
+This software is Copyright (c) 2010-2017 by the AUTHORS.
 
 This is free software, dual licensed under:
 

--- a/lib/App/RecordStream/Operation/tojsonarray.pm
+++ b/lib/App/RecordStream/Operation/tojsonarray.pm
@@ -1,0 +1,50 @@
+use strict;
+use warnings;
+use utf8;
+
+package App::RecordStream::Operation::tojsonarray;
+use base qw(App::RecordStream::Operation);
+
+sub init {
+  my $this = shift;
+  my $args = shift;
+  $this->parse_options($args);
+  $this->{COUNT} = 0;
+}
+
+sub accept_line {
+  my $this = shift;
+  my $line = shift;
+  $this->push_line(
+    $this->{COUNT}++ == 0
+      ? "[$line"
+      : ",$line"
+  );
+  return 1;
+}
+
+sub stream_done {
+  my $this = shift;
+  $this->push_line(
+    $this->{COUNT}
+      ? "]"
+      : "[]"
+  );
+}
+
+sub usage {
+  my $this = shift;
+  return <<USAGE;
+Usage: recs tojsonarray [files]
+   __FORMAT_TEXT__
+   This command outputs the record stream as a single JSON array.  It
+   complements the fromjsonarray command.
+   __FORMAT_TEXT__
+
+Examples
+  # Save the record stream to a file suitable for loading by any JSON parser
+  ... | recs tojsonarray > recs.json
+USAGE
+}
+
+1;

--- a/lib/App/RecordStream/OutputStream.pm
+++ b/lib/App/RecordStream/OutputStream.pm
@@ -45,6 +45,7 @@ my $json = JSON->new();
 $json->allow_nonref(1);
 $json->allow_blessed(1);
 $json->convert_blessed(1);
+$json->canonical(1) if $ENV{HARNESS_ACTIVE};
 
 sub hashref_string {
   my $record = shift;

--- a/tests/RecordStream/Operation/tojsonarray.t
+++ b/tests/RecordStream/Operation/tojsonarray.t
@@ -1,0 +1,35 @@
+use strict;
+use warnings;
+
+use Test::More;
+use App::RecordStream::Test::OperationHelper;
+use App::RecordStream::Operation::tojsonarray;
+
+my ($input, $output);
+
+# Basic
+$input = <<'INPUT';
+{"a":1,"foo":"bar"}
+{"a":2,"b":2}
+{"c":3}
+{"b":4}
+INPUT
+
+$output = <<'OUTPUT';
+[{"a":1,"foo":"bar"}
+,{"a":2,"b":2}
+,{"c":3}
+,{"b":4}
+]
+OUTPUT
+
+App::RecordStream::Test::OperationHelper->test_output('tojsonarray', [], $input, $output);
+
+
+# Empty
+$input  = "";
+$output = "[]\n";
+App::RecordStream::Test::OperationHelper->test_output('tojsonarray', [], $input, $output);
+
+
+done_testing;


### PR DESCRIPTION
Complements fromjsonarray and makes it easy to turn a record stream into a JSON file suitable for loading by any JSON parser.