### PR TITLE
Let recs run Perl scripts under an environment with the libraries available

### DIFF
--- a/bin/recs
+++ b/bin/recs
@@ -4,6 +4,7 @@ use warnings;
 no warnings 'exec';
 
 our $VERSION;
+our $FATPACKED = 0;
 
 use App::RecordStream;
 use App::RecordStream::Site;
@@ -120,7 +121,7 @@ sub _path_ops {
 
 sub version {
   print "recs/" . ($VERSION || $App::RecordStream::VERSION);
-  print " (fatpacked)" if grep { ref =~ /^FatPacked/ } @INC;
+  print " (fatpacked)" if $FATPACKED;
   print "\n";
   if (my @sites = App::RecordStream::Site::list_sites()) {
     print "Loaded sites:\n";

--- a/bin/recs
+++ b/bin/recs
@@ -14,6 +14,10 @@ use Getopt::Long;
 
 App::RecordStream::Site::bootstrap();
 
+# This is required before GetOptions() since an initial "--" isn't passed
+# through, despite what the documentation says.
+my $initial_dashdash = (@ARGV and $ARGV[0] eq "--");
+
 Getopt::Long::Configure(qw( require_order pass_through ));
 GetOptions(
   'h|help'          => sub { print usage(); exit },
@@ -21,6 +25,27 @@ GetOptions(
   'version'         => \&version,
 );
 
+
+# Does the first argument start with a slash (/) or a dot-slash (./)?
+my $looks_like_a_file = (@ARGV and $ARGV[0] =~ m{^[.]?/});
+
+# Run a Perl script in this process with our bundled libraries available.
+if ($initial_dashdash or $looks_like_a_file) {
+  my $file = shift @ARGV or die usage();
+
+  trace("Running file: $file");
+  my $rv = do $file;
+
+  if (not defined $rv) {
+    # Pass through compile/runtime errors unmodified
+    die $@ if $@;
+    die "Couldn't read file $file: $!\n" if $!;
+  }
+  exit;
+}
+
+
+# Run a subcommand
 my $operation = shift or die usage();
 my $recs = basename($0);
 
@@ -40,6 +65,17 @@ else {
       trace("Failed to exec recs-$operation: $!");
       print STDERR "$recs: '$operation' is not a recs command.\n\n";
       print STDERR "Use `$recs --list-commands` to see known commands.\n";
+
+      if (-e $operation) {
+        print STDERR <<"DIAG";
+
+Is '$operation' a Perl script you want to run under recs?  I thought it was a
+command name!  Try proceeding it with a '--' on the command line, like this:
+
+   recs -- $operation ...
+DIAG
+      }
+
       exit 1;
   };
 }
@@ -50,6 +86,9 @@ usage: recs command [arguments]
        recs -l|--list-commands
        recs -h|--help
        recs --version
+
+       recs ./file.pl [arguments]     # Runs the given Perl script with the
+       recs -- file.pl [arguments]    # App::RecordStream libraries available
 
 Run `recs examples` to see examples and `recs story` to read a humorous
 introduction to recs.

--- a/devel/fatpack-recs
+++ b/devel/fatpack-recs
@@ -27,3 +27,6 @@ perl -pi -e 's{^#!perl$}{#!/usr/bin/env perl}' recs
 
 echo "Setting version to $version"
 perl -pi -e "s/(?<=^our \\\$VERSION)(?=;)/ = '$version'/" recs
+
+echo "Setting fatpack status"
+perl -pi -e "s/(?<=^our \\\$FATPACKED = )0(?=;)/1/" recs

--- a/tests/RecordStream/recs-fatpack.t
+++ b/tests/RecordStream/recs-fatpack.t
@@ -24,6 +24,15 @@ ok !keys %core_ops, '-l outputs all the core ops'
 # test aggregator (BaseRegistry) discovery
 is fatpack_ok('collate -a count', { stdin => '{}' }), '{"count":1}', 'json matches';
 
+# test running of external scripts, with standalone path and -- delimiter
+my $script = "$ENV{'BASE_TEST_DIR'}/files/load-test.pl";
+like fatpack_ok($script),       qr/^FatPacked::/, 'loaded module from fatpack';
+like fatpack_ok("--", $script), qr/^FatPacked::/, 'loaded module from fatpack';
+
+# test running of external scripts, with args
+is fatpack_ok("--", $script, qw[ foo bar baz ]), 'foo bar baz', 'args passed';
+
+
 sub fatpack_ok {
   my $opt = ref $_[-1] eq 'HASH' ? pop @_ : {};
   my $cmd = join ' ', $^X, '-Mlib::core::only', $recs, @_;

--- a/tests/files/load-test.pl
+++ b/tests/files/load-test.pl
@@ -1,0 +1,6 @@
+use App::RecordStream::Operation::fromcsv;
+if (@ARGV) {
+  print join(" ", @ARGV), "\n";
+} else {
+  print $INC{'App/RecordStream/Operation/fromcsv.pm'}, "\n";
+}


### PR DESCRIPTION
While this is not that useful if App::RecordStream is installed, it's can be very useful when using the standalone bundle since the libraries are only available inside the bundle.  Portability++!