### PR TITLE
specify pg_enable_utf8 => 0 in recs-fromdb --type pg

### DIFF
--- a/lib/App/RecordStream/DBHandle.pm
+++ b/lib/App/RecordStream/DBHandle.pm
@@ -166,7 +166,7 @@ sub pg_dbh {
   my $dbh = DBI->connect("DBI:Pg:database=$database;host=$host",
     $user,
     $password,
-    { RaiseError => 1, PrintError => 0 });
+    { RaiseError => 1, PrintError => 0, pg_enable_utf8 => 0 });
 
   return $dbh;
 }


### PR DESCRIPTION
DBD::Pg has returned UTF8-decode since 3.0.0.
https://metacpan.org/pod/DBD::Pg#pg_enable_utf8-(integer)

The internal handling of RecordStream is byte.

Suppress the warning below.
> Wide character in print at /usr/local/lib/perl5/site_perl/App/RecordStream/Stream/Printer.pm line 12.