### PR TITLE
Fix Perl vs TypeScript comparison gaps

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@types/react": "^19.2.14",
         "better-sqlite3": "^12.6.2",
+        "chrono-node": "^2.9.0",
         "exceljs": "^4.4.0",
         "fast-xml-parser": "^5.3.7",
         "ink": "^6.8.0",
@@ -22,6 +23,7 @@
         "pg": "^8.18.0",
         "react": "^19.2.4",
         "string-width": "^8.2.0",
+        "woothee": "^1.11.1",
       },
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.13",
@@ -382,6 +384,8 @@
     "character-entities-legacy": ["character-entities-legacy@3.0.0", "", {}, "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="],
 
     "chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
+
+    "chrono-node": ["chrono-node@2.9.0", "", {}, "sha512-glI4YY2Jy6JII5l3d5FN6rcrIbKSQqKPhWsIRYPK2IK8Mm4Q1ZZFdYIaDqglUNf7gNwG+kWIzTn0omzzE0VkvQ=="],
 
     "cli-boxes": ["cli-boxes@3.0.0", "", {}, "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g=="],
 
@@ -830,6 +834,8 @@
     "whatwg-url": ["whatwg-url@14.2.0", "", { "dependencies": { "tr46": "^5.1.0", "webidl-conversions": "^7.0.0" } }, "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw=="],
 
     "widest-line": ["widest-line@6.0.0", "", { "dependencies": { "string-width": "^8.1.0" } }, "sha512-U89AsyEeAsyoF0zVJBkG9zBgekjgjK7yk9sje3F4IQpXBJ10TF6ByLlIfjMhcmHMJgHZI4KHt4rdNfktzxIAMA=="],
+
+    "woothee": ["woothee@1.11.1", "", {}, "sha512-KdArM3MsNa5tlSBSL29w9ouy9MXZoFPeUdPVnL4QZH3iyV8HsqnwbWw2YLiXEx2wAh0bM55dnl0+qDE6KHBlhQ=="],
 
     "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@types/react": "^19.2.14",
     "better-sqlite3": "^12.6.2",
+    "chrono-node": "^2.9.0",
     "exceljs": "^4.4.0",
     "fast-xml-parser": "^5.3.7",
     "ink": "^6.8.0",
@@ -47,6 +48,7 @@
     "papaparse": "^5.5.3",
     "pg": "^8.18.0",
     "react": "^19.2.4",
-    "string-width": "^8.2.0"
+    "string-width": "^8.2.0",
+    "woothee": "^1.11.1"
   }
 }

--- a/src/aggregators/Ord2Bivariate.ts
+++ b/src/aggregators/Ord2Bivariate.ts
@@ -1,0 +1,97 @@
+import type { Aggregator } from "../Aggregator.ts";
+import type { Record } from "../Record.ts";
+import type { JsonValue } from "../types/json.ts";
+import { findKey } from "../KeySpec.ts";
+import { aggregatorRegistry } from "../Aggregator.ts";
+
+// [sum1, sumX, sumY, sumXY, sumX2, sumY2]
+type Ord2BivState = [number, number, number, number, number, number];
+
+/**
+ * Second-order bivariate statistics aggregator.
+ * Computes covariance, correlation, and linear regression parameters
+ * between two fields using a single pass.
+ *
+ * Analogous to App::RecordStream::Aggregator::Ord2Bivariate in Perl.
+ */
+export class Ord2BivariateAggregator implements Aggregator<Ord2BivState | null> {
+  fieldX: string;
+  fieldY: string;
+
+  constructor(fieldX: string, fieldY: string) {
+    this.fieldX = fieldX;
+    this.fieldY = fieldY;
+  }
+
+  initial(): Ord2BivState | null {
+    return null;
+  }
+
+  combine(state: Ord2BivState | null, record: Record): Ord2BivState | null {
+    const vx = findKey(record.dataRef(), this.fieldX, true);
+    const vy = findKey(record.dataRef(), this.fieldY, true);
+    if (vx === undefined || vx === null || vy === undefined || vy === null) return state;
+    const x = Number(vx);
+    const y = Number(vy);
+    const mapped: Ord2BivState = [1, x, y, x * y, x * x, y * y];
+    if (state === null) return mapped;
+    return [
+      state[0] + mapped[0],
+      state[1] + mapped[1],
+      state[2] + mapped[2],
+      state[3] + mapped[3],
+      state[4] + mapped[4],
+      state[5] + mapped[5],
+    ];
+  }
+
+  squish(state: Ord2BivState | null): JsonValue {
+    if (state === null) return null;
+    const [n, sumX, sumY, sumXY, sumX2, sumY2] = state;
+
+    const meanX = sumX / n;
+    const meanY = sumY / n;
+
+    // Covariance: E[XY] - E[X]*E[Y]
+    const covariance = sumXY / n - meanX * meanY;
+
+    // Variances
+    const varX = sumX2 / n - meanX * meanX;
+    const varY = sumY2 / n - meanY * meanY;
+
+    // Correlation: cov / (stdX * stdY)
+    const denominator = Math.sqrt(varX * varY);
+    const correlation = denominator > 0
+      ? (sumXY * n - sumX * sumY) / Math.sqrt((sumX2 * n - sumX ** 2) * (sumY2 * n - sumY ** 2))
+      : null;
+
+    // Linear regression: y = alpha + beta * x
+    const betaDenom = sumX2 * n - sumX ** 2;
+    const beta = betaDenom !== 0 ? (sumXY * n - sumX * sumY) / betaDenom : null;
+    const alpha = beta !== null ? (sumY - beta * sumX) / n : null;
+
+    const result: { [key: string]: JsonValue } = {
+      count: n,
+      covariance,
+      correlation,
+    };
+
+    if (alpha !== null && beta !== null) {
+      result["alpha"] = alpha;
+      result["beta"] = beta;
+    }
+
+    return result;
+  }
+}
+
+aggregatorRegistry.register("ord2biv", {
+  create: (fieldX: string, fieldY: string) => new Ord2BivariateAggregator(fieldX, fieldY),
+  argCounts: [2],
+  shortUsage: "compute second-order bivariate statistics for two fields",
+  longUsage:
+    "Usage: ord2biv,<field1>,<field2>\n" +
+    "   Compute covariance, correlation, and linear regression parameters\n" +
+    "   between two fields.",
+  aliases: ["ord2bivariate"],
+});

--- a/src/aggregators/Ord2Univariate.ts
+++ b/src/aggregators/Ord2Univariate.ts
@@ -1,0 +1,82 @@
+import type { Aggregator } from "../Aggregator.ts";
+import type { Record } from "../Record.ts";
+import type { JsonValue } from "../types/json.ts";
+import { findKey } from "../KeySpec.ts";
+import { aggregatorRegistry } from "../Aggregator.ts";
+
+// [count, sumX, sumX2, sumX3, sumX4]
+type Ord2UniState = [number, number, number, number, number];
+
+/**
+ * Second-order univariate statistics aggregator.
+ * Computes count, mean, variance, standard deviation, skewness, and kurtosis
+ * for a single field using a single pass.
+ *
+ * Analogous to App::RecordStream::Aggregator::Ord2Univariate in Perl.
+ */
+export class Ord2UnivariateAggregator implements Aggregator<Ord2UniState | null> {
+  field: string;
+
+  constructor(field: string) {
+    this.field = field;
+  }
+
+  initial(): Ord2UniState | null {
+    return null;
+  }
+
+  combine(state: Ord2UniState | null, record: Record): Ord2UniState | null {
+    const value = findKey(record.dataRef(), this.field, true);
+    if (value === undefined || value === null) return state;
+    const x = Number(value);
+    const mapped: Ord2UniState = [1, x, x * x, x * x * x, x * x * x * x];
+    if (state === null) return mapped;
+    return [
+      state[0] + mapped[0],
+      state[1] + mapped[1],
+      state[2] + mapped[2],
+      state[3] + mapped[3],
+      state[4] + mapped[4],
+    ];
+  }
+
+  squish(state: Ord2UniState | null): JsonValue {
+    if (state === null) return null;
+    const [n, sumX, sumX2, sumX3, sumX4] = state;
+
+    const mean = sumX / n;
+    const variance = sumX2 / n - mean * mean;
+    const stddev = Math.sqrt(variance);
+
+    const result: { [key: string]: JsonValue } = {
+      count: n,
+      mean,
+      variance,
+      stddev,
+    };
+
+    // Skewness and kurtosis require variance > 0
+    if (variance > 0) {
+      // E[(X - mean)^3] = E[X^3] - 3*mean*E[X^2] + 2*mean^3
+      const m3 = sumX3 / n - 3 * mean * (sumX2 / n) + 2 * mean * mean * mean;
+      result["skewness"] = m3 / (stddev * stddev * stddev);
+
+      // E[(X - mean)^4] = E[X^4] - 4*mean*E[X^3] + 6*mean^2*E[X^2] - 3*mean^4
+      const m4 = sumX4 / n - 4 * mean * (sumX3 / n) + 6 * mean * mean * (sumX2 / n) - 3 * mean * mean * mean * mean;
+      result["kurtosis"] = m4 / (variance * variance);
+    }
+
+    return result;
+  }
+}
+
+aggregatorRegistry.register("ord2uni", {
+  create: (field: string) => new Ord2UnivariateAggregator(field),
+  argCounts: [1],
+  shortUsage: "compute second-order univariate statistics for a field",
+  longUsage:
+    "Usage: ord2uni,<field>\n" +
+    "   Compute count, mean, variance, standard deviation, skewness,\n" +
+    "   and kurtosis for the specified field.",
+  aliases: ["ord2univariate"],
+});

--- a/src/aggregators/registry.ts
+++ b/src/aggregators/registry.ts
@@ -33,5 +33,7 @@ import "./FirstRecord.ts";
 import "./LastRecord.ts";
 import "./RecordForMaximum.ts";
 import "./RecordForMinimum.ts";
+import "./Ord2Univariate.ts";
+import "./Ord2Bivariate.ts";
 
 export { aggregatorRegistry, makeAggregators } from "../Aggregator.ts";

--- a/src/deaggregators/registry.ts
+++ b/src/deaggregators/registry.ts
@@ -1,0 +1,11 @@
+/**
+ * Deaggregator registry - central place for registering and looking up
+ * deaggregators by name.
+ *
+ * Importing this module ensures all deaggregator implementations are registered.
+ */
+
+// Import all deaggregator implementations to trigger their self-registration
+import "./Split.ts";
+import "./Unarray.ts";
+import "./Unhash.ts";

--- a/src/operations/input/fromtcpdump.ts
+++ b/src/operations/input/fromtcpdump.ts
@@ -49,15 +49,14 @@ export class FromTcpdump extends Operation {
   }
 
   dumpPackets(file: string): void {
-    // Use tcpdump to read pcap file and output verbose text
     const tcpdumpArgs = [
       "tcpdump",
       "-r",
       file,
-      "-nn",     // Don't resolve addresses or ports
-      "-tt",     // Print unformatted timestamp
-      "-v",      // Verbose
-      "-e",      // Print link-layer header
+      "-nn", // Don't resolve addresses or ports
+      "-tt", // Print unformatted timestamp
+      "-vv", // Very verbose (includes checksums)
+      "-e", // Print link-layer header (MAC addresses)
     ];
 
     if (this.includeData) {
@@ -73,75 +72,326 @@ export class FromTcpdump extends Operation {
     }
 
     const output = result.stdout.toString();
-    const lines = output.split("\n").filter((l) => l.trim() !== "");
+    const lines = output.split("\n");
 
+    // Group lines into packets: a new packet starts with a timestamp,
+    // continuation lines start with whitespace
+    const packets: string[][] = [];
     for (const line of lines) {
-      const record = this.parsePacketLine(line, file);
+      if (line.trim() === "") continue;
+      if (/^\d+\.\d+\s/.test(line)) {
+        packets.push([line]);
+      } else if (packets.length > 0) {
+        packets[packets.length - 1]!.push(line);
+      }
+    }
+
+    for (const packetLines of packets) {
+      const record = this.parsePacket(packetLines, file);
       if (record) {
         this.pushRecord(new Record(record));
       }
     }
   }
 
-  parsePacketLine(line: string, file: string): JsonObject | null {
+  parsePacket(lines: string[], file: string): JsonObject | null {
     const record: JsonObject = { file };
+    const headerLine = lines[0]!;
+
+    // Combine continuation lines, filtering out hex dump lines (from -X)
+    const detailLines = lines
+      .slice(1)
+      .filter((l) => !l.trim().startsWith("0x"))
+      .map((l) => l.trim())
+      .join(" ");
 
     // Parse timestamp
-    const tsMatch = line.match(/^(\d+\.\d+)\s+/);
+    const tsMatch = headerLine.match(/^(\d+\.\d+)\s+/);
     if (tsMatch) {
       record["timestamp"] = tsMatch[1]!;
     }
 
-    // Parse basic IP info
-    const ipMatch = line.match(
-      /IP\s+(\S+?)\.(\d+)\s+>\s+(\S+?)\.(\d+):/
-    );
-    if (ipMatch) {
-      record["ip"] = {
-        src_ip: ipMatch[1]!,
-        dest_ip: ipMatch[3]!,
-      } as JsonValue;
+    // Parse ethernet MAC addresses from -e output
+    this.parseEthernet(headerLine, record);
 
-      // Determine protocol
-      if (line.includes("UDP")) {
-        record["type"] = "udp";
-        record["udp"] = {
-          src_port: parseInt(ipMatch[2]!, 10),
-          dest_port: parseInt(ipMatch[4]!, 10),
-        } as JsonValue;
-      } else {
-        record["type"] = "tcp";
-        record["tcp"] = {
-          src_port: parseInt(ipMatch[2]!, 10),
-          dest_port: parseInt(ipMatch[4]!, 10),
-        } as JsonValue;
-
-        // Parse TCP flags
-        const flagsMatch = line.match(/Flags \[([^\]]*)\]/);
-        if (flagsMatch) {
-          const flagStr = flagsMatch[1]!;
-          const flags: JsonObject = {};
-          if (flagStr.includes("S")) flags["SYN"] = 1;
-          if (flagStr.includes("F")) flags["FIN"] = 1;
-          if (flagStr.includes("R")) flags["RST"] = 1;
-          if (flagStr.includes("P")) flags["PSH"] = 1;
-          if (flagStr.includes(".")) flags["ACK"] = 1;
-          (record["tcp"] as JsonObject)["flags"] = flags;
-        }
-      }
-    } else if (line.includes("ARP")) {
-      record["type"] = "arp";
-    } else {
-      record["type"] = "ethernet";
+    // Parse frame length from ethernet header: ", length N:"
+    const frameLenMatch = headerLine.match(/,\s+length\s+(\d+):/);
+    if (frameLenMatch) {
+      record["length"] = parseInt(frameLenMatch[1]!, 10);
     }
 
-    // Parse length
-    const lenMatch = line.match(/length\s+(\d+)/);
-    if (lenMatch) {
-      record["length"] = parseInt(lenMatch[1]!, 10);
+    // Determine packet type and parse protocol details
+    if (
+      headerLine.includes("ethertype IPv4") ||
+      headerLine.includes("ethertype IPv6")
+    ) {
+      this.parseIpPacket(headerLine, detailLines, record);
+    } else if (
+      headerLine.includes("ethertype ARP") ||
+      headerLine.includes("ARP")
+    ) {
+      record["type"] = "arp";
+      this.parseArpDetails(headerLine + " " + detailLines, record);
+    } else {
+      record["type"] = "ethernet";
+      // Fallback length parsing
+      if (!record["length"]) {
+        const lenMatch = headerLine.match(/length\s+(\d+)/);
+        if (lenMatch) {
+          record["length"] = parseInt(lenMatch[1]!, 10);
+        }
+      }
     }
 
     return record;
+  }
+
+  parseEthernet(line: string, record: JsonObject): void {
+    // Format after timestamp: SRC_MAC > DEST_MAC, ethertype ...
+    const macMatch = line.match(
+      /^[\d.]+\s+([\da-f]{2}:[\da-f]{2}:[\da-f]{2}:[\da-f]{2}:[\da-f]{2}:[\da-f]{2})\s+>\s+([\da-f]{2}:[\da-f]{2}:[\da-f]{2}:[\da-f]{2}:[\da-f]{2}:[\da-f]{2})/i
+    );
+    if (macMatch) {
+      record["ethernet"] = {
+        src_mac: macMatch[1]!,
+        dest_mac: macMatch[2]!,
+      } as JsonValue;
+    }
+  }
+
+  parseIpPacket(
+    headerLine: string,
+    detailLines: string,
+    record: JsonObject
+  ): void {
+    const ip: JsonObject = {};
+
+    // Parse IP header: (tos 0xN, ttl N, id N, offset N, flags [...], proto TYPE (N), length N)
+    const ipHeaderMatch = headerLine.match(
+      /\(tos\s+(0x[\da-f]+),\s*ttl\s+(\d+),\s*id\s+(\d+),\s*offset\s+(\d+),\s*flags\s+\[([^\]]*)\],\s*proto\s+(\w+)\s+\((\d+)\),\s*length\s+(\d+)\)/i
+    );
+    if (ipHeaderMatch) {
+      ip["tos"] = parseInt(ipHeaderMatch[1]!, 16);
+      ip["ttl"] = parseInt(ipHeaderMatch[2]!, 10);
+      ip["id"] = parseInt(ipHeaderMatch[3]!, 10);
+      ip["offset"] = parseInt(ipHeaderMatch[4]!, 10);
+      ip["proto"] = parseInt(ipHeaderMatch[7]!, 10);
+      ip["len"] = parseInt(ipHeaderMatch[8]!, 10);
+
+      // Parse IP flags
+      const flagStr = ipHeaderMatch[5]!;
+      const ipFlags: JsonObject = {};
+      if (flagStr.includes("DF")) ipFlags["dont_fragment"] = 1;
+      if (flagStr.includes("MF")) ipFlags["more_fragments"] = 1;
+      if (/\bCE\b/.test(flagStr)) ipFlags["congestion"] = 1;
+      ip["flags"] = ipFlags;
+    }
+
+    // Parse IP addresses and ports from detail line
+    // Format: src_ip.src_port > dest_ip.dest_port:
+    const addrMatch = detailLines.match(
+      /(\S+?)\.(\d+)\s+>\s+(\S+?)\.(\d+):/
+    );
+    if (addrMatch) {
+      ip["src_ip"] = addrMatch[1]!;
+      ip["dest_ip"] = addrMatch[3]!;
+      const srcPort = parseInt(addrMatch[2]!, 10);
+      const destPort = parseInt(addrMatch[4]!, 10);
+      record["ip"] = ip as JsonValue;
+
+      // Determine transport protocol
+      if (
+        headerLine.includes("proto UDP") ||
+        detailLines.includes(" UDP,")
+      ) {
+        record["type"] = "udp";
+        const udp: JsonObject = {
+          src_port: srcPort,
+          dest_port: destPort,
+        };
+        this.parseUdpDetails(detailLines, udp);
+        record["udp"] = udp as JsonValue;
+
+        if (srcPort === 53 || destPort === 53) {
+          this.parseDnsDetails(detailLines, record);
+        }
+      } else {
+        record["type"] = "tcp";
+        const tcp: JsonObject = {
+          src_port: srcPort,
+          dest_port: destPort,
+        };
+        this.parseTcpDetails(detailLines, tcp);
+        record["tcp"] = tcp as JsonValue;
+
+        if (srcPort === 53 || destPort === 53) {
+          this.parseDnsDetails(detailLines, record);
+        }
+      }
+    } else {
+      // IP packet without clear port info (e.g. ICMP)
+      record["ip"] = ip as JsonValue;
+      record["type"] = "ip";
+    }
+  }
+
+  parseTcpDetails(detail: string, tcp: JsonObject): void {
+    // TCP flags: Flags [S.], [P.], [SEWU.], etc.
+    // S=SYN, F=FIN, R=RST, P=PSH, .=ACK, U=URG, E=ECE, W=CWR
+    const flagsMatch = detail.match(/Flags\s+\[([^\]]*)\]/);
+    if (flagsMatch) {
+      const flagStr = flagsMatch[1]!;
+      const flags: JsonObject = {};
+      if (flagStr.includes("S")) flags["SYN"] = 1;
+      if (flagStr.includes("F")) flags["FIN"] = 1;
+      if (flagStr.includes("R")) flags["RST"] = 1;
+      if (flagStr.includes("P")) flags["PSH"] = 1;
+      if (flagStr.includes(".")) flags["ACK"] = 1;
+      if (flagStr.includes("U")) flags["URG"] = 1;
+      if (flagStr.includes("E")) flags["ECE"] = 1;
+      if (flagStr.includes("W")) flags["CWR"] = 1;
+      tcp["flags"] = flags;
+    }
+
+    // seq N or seq N:M
+    const seqMatch = detail.match(/\bseq\s+(\d+)(?::(\d+))?/);
+    if (seqMatch) {
+      tcp["seq"] = parseInt(seqMatch[1]!, 10);
+      if (seqMatch[2]) {
+        tcp["seq_end"] = parseInt(seqMatch[2]!, 10);
+      }
+    }
+
+    // ack N
+    const ackMatch = detail.match(/\back\s+(\d+)/);
+    if (ackMatch) {
+      tcp["ack"] = parseInt(ackMatch[1]!, 10);
+    }
+
+    // win N
+    const winMatch = detail.match(/\bwin\s+(\d+)/);
+    if (winMatch) {
+      tcp["win"] = parseInt(winMatch[1]!, 10);
+    }
+
+    // cksum 0xNNNN
+    const cksumMatch = detail.match(/\bcksum\s+(0x[\da-f]+)/i);
+    if (cksumMatch) {
+      tcp["cksum"] = parseInt(cksumMatch[1]!, 16);
+    }
+
+    // options [...]
+    const optMatch = detail.match(/\boptions\s+\[([^\]]*)\]/);
+    if (optMatch) {
+      tcp["options"] = optMatch[1]!;
+    }
+
+    // TCP payload length at end of line
+    const lenMatch = detail.match(/\blength\s+(\d+)\s*$/);
+    if (lenMatch) {
+      tcp["data_length"] = parseInt(lenMatch[1]!, 10);
+    }
+  }
+
+  parseUdpDetails(detail: string, udp: JsonObject): void {
+    // UDP checksum: [bad udp cksum 0xNNNN -> 0xNNNN!]
+    const cksumMatch = detail.match(/udp cksum\s+(0x[\da-f]+)/i);
+    if (cksumMatch) {
+      udp["cksum"] = parseInt(cksumMatch[1]!, 16);
+    }
+
+    // Data length from trailing (N) — UDP length = data + 8 byte header
+    const dataLenMatch = detail.match(/\((\d+)\)\s*$/);
+    if (dataLenMatch) {
+      const dataLen = parseInt(dataLenMatch[1]!, 10);
+      udp["len"] = dataLen + 8;
+    }
+  }
+
+  parseDnsDetails(detail: string, record: JsonObject): void {
+    const dns: JsonObject = {};
+
+    // DNS query: ID[flags] QTYPE? QNAME. (len)
+    // Example: 3930+ A? blog.benjaminbernard.com. (42)
+    const queryMatch = detail.match(
+      /:\s+(?:\[.*?\]\s+)?(\d+)([+*%-]*)\s+(\w+)\?\s+(\S+?)\.\s+\((\d+)\)/
+    );
+    if (queryMatch) {
+      dns["id"] = parseInt(queryMatch[1]!, 10);
+      dns["qr"] = 0;
+      dns["question"] = [
+        { qname: queryMatch[4]!, qtype: queryMatch[3]! },
+      ] as JsonValue;
+      dns["answer"] = [] as JsonValue;
+      record["dns"] = dns as JsonValue;
+      return;
+    }
+
+    // DNS response: ID[flags] q: QTYPE? QNAME. AN/NS/AR answers...
+    // Example: 3930 q: A? blog.benjaminbernard.com. 6/0/0 blog... A 1.2.3.4, ...
+    const responseMatch = detail.match(
+      /:\s+(?:\[.*?\]\s+)?(\d+)([+*%-]*)\s+(?:q:\s+)?(\w+)\?\s+(\S+?)\.\s+(\d+)\/(\d+)\/(\d+)\s+(.*)/
+    );
+    if (responseMatch) {
+      dns["id"] = parseInt(responseMatch[1]!, 10);
+      dns["qr"] = 1;
+      dns["question"] = [
+        { qname: responseMatch[4]!, qtype: responseMatch[3]! },
+      ] as JsonValue;
+      dns["counts"] = {
+        answer: parseInt(responseMatch[5]!, 10),
+        authority: parseInt(responseMatch[6]!, 10),
+        additional: parseInt(responseMatch[7]!, 10),
+      } as JsonValue;
+      dns["answer"] = this.parseDnsAnswers(responseMatch[8]!) as JsonValue;
+      record["dns"] = dns as JsonValue;
+    }
+  }
+
+  parseDnsAnswers(answersStr: string): JsonValue[] {
+    const answers: JsonValue[] = [];
+    // Remove trailing (len)
+    const cleaned = answersStr.replace(/\s*\(\d+\)\s*$/, "");
+    const parts = cleaned.split(/,\s*/);
+    for (const part of parts) {
+      const trimmed = part.trim();
+      if (!trimmed) continue;
+      // Match: name. TYPE data
+      const rrMatch = trimmed.match(/^(\S+?)\.?\s+(\w+)\s+(.+)$/);
+      if (rrMatch) {
+        answers.push({
+          name: rrMatch[1]!,
+          type: rrMatch[2]!,
+          data: rrMatch[3]!,
+        });
+      }
+    }
+    return answers;
+  }
+
+  parseArpDetails(text: string, record: JsonObject): void {
+    const arp: JsonObject = {};
+
+    // ARP Request: Request who-has TARGET_IP tell SENDER_IP
+    const requestMatch = text.match(
+      /Request\s+who-has\s+([^\s,]+)\s+tell\s+([^\s,]+)/
+    );
+    if (requestMatch) {
+      arp["opcode"] = "ARP_REQUEST";
+      arp["target_ip"] = requestMatch[1]!;
+      arp["sender_ip"] = requestMatch[2]!;
+      record["arp"] = arp as JsonValue;
+      return;
+    }
+
+    // ARP Reply: Reply SENDER_IP is-at SENDER_MAC
+    const replyMatch = text.match(/Reply\s+([^\s,]+)\s+is-at\s+([^\s,]+)/);
+    if (replyMatch) {
+      arp["opcode"] = "ARP_REPLY";
+      arp["sender_ip"] = replyMatch[1]!;
+      arp["sender_mac"] = replyMatch[2]!;
+      record["arp"] = arp as JsonValue;
+    }
   }
 }
 

--- a/src/operations/output/todb.ts
+++ b/src/operations/output/todb.ts
@@ -5,7 +5,7 @@ import type { JsonValue } from "../../types/json.ts";
 
 /**
  * Writes records to a SQL database.
- * Supports SQLite (via bun:sqlite), with extensibility for other databases.
+ * Supports SQLite (via bun:sqlite), PostgreSQL (via pg), and MySQL (via mysql2).
  *
  * Analogous to App::RecordStream::Operation::todb in Perl.
  */
@@ -13,12 +13,19 @@ export class ToDb extends Operation {
   tableName = "recs";
   debug = false;
   dropTable = false;
-  fields: Map<string, string> = new Map(); // field name -> SQL type (0 = default VARCHAR)
+  fields: Map<string, string> = new Map(); // field name -> SQL type ("" = default VARCHAR)
   first = true;
   dbFile = "";
   dbType = "sqlite";
+  host: string | null = null;
+  port: string | null = null;
+  dbName: string | null = null;
+  user: string | null = null;
+  password: string | null = null;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Database instance type depends on runtime
   db: { run: (sql: string) => void; close: () => void } | null = null;
+  // Buffered records for async DB types (pg, mysql)
+  pendingRecords: Record[] = [];
 
   constructor(next?: RecordReceiver) {
     super(next);
@@ -92,42 +99,95 @@ export class ToDb extends Operation {
         long: "type",
         type: "string",
         handler: (v) => { this.dbType = v as string; },
-        description: "Database type (sqlite)",
+        description: "Database type: sqlite (default), pg, mysql",
+      },
+      {
+        long: "host",
+        type: "string",
+        handler: (v) => { this.host = v as string; },
+        description: "Hostname for database connection (pg, mysql)",
+      },
+      {
+        long: "port",
+        type: "string",
+        handler: (v) => { this.port = v as string; },
+        description: "Port for database connection (pg, mysql)",
+      },
+      {
+        long: "db",
+        type: "string",
+        handler: (v) => { this.dbName = v as string; },
+        description: "Database name (pg, mysql)",
+      },
+      {
+        long: "dbname",
+        type: "string",
+        handler: (v) => { this.dbName = v as string; },
+        description: "Database name (alias for --db)",
+      },
+      {
+        long: "user",
+        type: "string",
+        handler: (v) => { this.user = v as string; },
+        description: "Database user",
+      },
+      {
+        long: "password",
+        type: "string",
+        handler: (v) => { this.password = v as string; },
+        description: "Database password",
       },
     ];
 
     this.parseOptions(args, defs);
 
-    if (!this.dbFile) {
-      this.dbFile = ":memory:";
+    if (this.dbType === "postgres") {
+      this.dbType = "pg";
     }
 
-    this.initDb();
+    if (this.dbType === "pg" && !this.dbName) {
+      throw new Error("--db is required for PostgreSQL databases");
+    }
 
-    if (this.dropTable) {
-      try {
-        this.dbDo(`DROP TABLE IF EXISTS "${this.tableName}"`);
-      } catch {
-        // Ignore errors from dropping a non-existent table
+    if (this.dbType === "mysql" && (!this.host || !this.dbName)) {
+      throw new Error("--host and --db are required for MySQL databases");
+    }
+
+    if (this.dbType === "sqlite") {
+      if (!this.dbFile) {
+        this.dbFile = ":memory:";
+      }
+      this.initSqliteDb();
+
+      if (this.dropTable) {
+        try {
+          this.dbDo(`DROP TABLE IF EXISTS "${this.tableName}"`);
+        } catch {
+          // Ignore errors from dropping a non-existent table
+        }
       }
     }
+    // For pg/mysql, connection is established asynchronously in finish()
   }
 
-  initDb(): void {
-    // Use Bun's built-in SQLite
+  initSqliteDb(): void {
     // eslint-disable-next-line @typescript-eslint/no-require-imports -- bun:sqlite is a runtime module
     const { Database } = require("bun:sqlite") as { Database: new (path: string) => { run: (sql: string) => void; close: () => void } };
     this.db = new Database(this.dbFile);
   }
 
   acceptRecord(record: Record): boolean {
-    if (this.first) {
-      this.addFields(record);
-      this.createTable();
-      this.first = false;
+    if (this.dbType === "sqlite") {
+      if (this.first) {
+        this.addFields(record);
+        this.createTable();
+        this.first = false;
+      }
+      this.addRow(record);
+    } else {
+      // Buffer records for async DB types
+      this.pendingRecords.push(record);
     }
-
-    this.addRow(record);
     return true;
   }
 
@@ -139,7 +199,7 @@ export class ToDb extends Operation {
     }
   }
 
-  addRow(record: Record): void {
+  buildInsertSql(record: Record): string {
     const data = record.dataRef();
     const keys = [...this.fields.keys()];
     const columns = keys.map((k) => `"${k}"`).join(",");
@@ -154,22 +214,40 @@ export class ToDb extends Operation {
       return `'${strVal.replace(/'/g, "''")}'`;
     }).join(",");
 
-    const sql = `INSERT INTO "${this.tableName}" (${columns}) VALUES (${values})`;
+    return `INSERT INTO "${this.tableName}" (${columns}) VALUES (${values})`;
+  }
+
+  addRow(record: Record): void {
+    const sql = this.buildInsertSql(record);
     this.dbDo(sql);
   }
 
-  createTable(): void {
-    const incrementName = this.dbType === "sqlite" ? "AUTOINCREMENT" : "AUTO_INCREMENT";
-    let sql = `CREATE TABLE IF NOT EXISTS "${this.tableName}" ( id INTEGER PRIMARY KEY ${incrementName}, `;
+  buildCreateTableSql(): string {
+    const incrementName = this.dbType === "sqlite" ? "AUTOINCREMENT" : (this.dbType === "pg" ? "GENERATED ALWAYS AS IDENTITY" : "AUTO_INCREMENT");
 
+    if (this.dbType === "pg") {
+      let sql = `CREATE TABLE IF NOT EXISTS "${this.tableName}" ( id INTEGER ${incrementName} PRIMARY KEY, `;
+      const columnDefs: string[] = [];
+      for (const [name, type] of this.fields) {
+        const sqlType = type || "VARCHAR(255)";
+        columnDefs.push(`"${name}" ${sqlType}`);
+      }
+      sql += columnDefs.join(", ") + " )";
+      return sql;
+    }
+
+    let sql = `CREATE TABLE IF NOT EXISTS "${this.tableName}" ( id INTEGER PRIMARY KEY ${incrementName}, `;
     const columnDefs: string[] = [];
     for (const [name, type] of this.fields) {
       const sqlType = type || "VARCHAR(255)";
       columnDefs.push(`"${name}" ${sqlType}`);
     }
-
     sql += columnDefs.join(", ") + " )";
+    return sql;
+  }
 
+  createTable(): void {
+    const sql = this.buildCreateTableSql();
     try {
       this.dbDo(sql);
     } catch {
@@ -185,7 +263,169 @@ export class ToDb extends Operation {
   }
 
   override streamDone(): void {
-    this.db?.close();
+    if (this.dbType === "sqlite") {
+      this.db?.close();
+    }
+    // For async types, cleanup happens in streamDoneAsync
+  }
+
+  async streamDoneAsync(): Promise<void> {
+    switch (this.dbType) {
+      case "sqlite":
+        this.db?.close();
+        break;
+      case "pg":
+        await this.flushPostgres();
+        break;
+      case "mysql":
+        await this.flushMysql();
+        break;
+      default:
+        throw new Error(
+          `Database type '${this.dbType}' is not supported. Supported types: sqlite, pg, mysql`
+        );
+    }
+  }
+
+  /**
+   * Override finish to support async database types.
+   * The dispatcher and executor both call `await op.finish()`, so returning
+   * a Promise here is correctly awaited at runtime even though the base
+   * class types this as void.
+   */
+  override finish(): void {
+    if (this.dbType === "sqlite") {
+      this.streamDone();
+      this.next.finish();
+      return;
+    }
+    // For async types (pg, mysql), return the Promise so the
+    // dispatcher's `await op.finish()` waits for it at runtime.
+    return this.streamDoneAsync().then(() => {
+      this.next.finish();
+    }) as unknown as void;
+  }
+
+  async flushPostgres(): Promise<void> {
+    const { Client } = await import("pg");
+
+    const config: {
+      database: string;
+      host?: string;
+      port?: number;
+      user?: string;
+      password?: string;
+    } = {
+      database: this.dbName!,
+    };
+
+    if (this.host) {
+      config.host = this.host;
+    }
+    if (this.port) {
+      config.port = parseInt(this.port, 10);
+    }
+    if (this.user) {
+      config.user = this.user;
+    }
+    if (this.password) {
+      config.password = this.password;
+    }
+
+    const client = new Client(config);
+    try {
+      await client.connect();
+
+      if (this.dropTable) {
+        const dropSql = `DROP TABLE IF EXISTS "${this.tableName}"`;
+        if (this.debug) {
+          this.pushLine("Running: " + dropSql);
+        }
+        await client.query(dropSql);
+      }
+
+      // Determine fields from first record if not specified
+      if (this.pendingRecords.length > 0 && this.fields.size === 0) {
+        this.addFields(this.pendingRecords[0]!);
+      }
+
+      if (this.fields.size > 0) {
+        const createSql = this.buildCreateTableSql();
+        if (this.debug) {
+          this.pushLine("Running: " + createSql);
+        }
+        await client.query(createSql);
+      }
+
+      for (const record of this.pendingRecords) {
+        const sql = this.buildInsertSql(record);
+        if (this.debug) {
+          this.pushLine("Running: " + sql);
+        }
+        await client.query(sql);
+      }
+    } finally {
+      await client.end();
+    }
+  }
+
+  async flushMysql(): Promise<void> {
+    const mysql = await import("mysql2/promise");
+
+    const config: {
+      host: string;
+      database: string;
+      port?: number;
+      user?: string;
+      password?: string;
+    } = {
+      host: this.host!,
+      database: this.dbName!,
+    };
+
+    if (this.port) {
+      config.port = parseInt(this.port, 10);
+    }
+    if (this.user) {
+      config.user = this.user;
+    }
+    if (this.password) {
+      config.password = this.password;
+    }
+
+    const connection = await mysql.createConnection(config);
+    try {
+      if (this.dropTable) {
+        const dropSql = `DROP TABLE IF EXISTS "${this.tableName}"`;
+        if (this.debug) {
+          this.pushLine("Running: " + dropSql);
+        }
+        await connection.execute(dropSql);
+      }
+
+      // Determine fields from first record if not specified
+      if (this.pendingRecords.length > 0 && this.fields.size === 0) {
+        this.addFields(this.pendingRecords[0]!);
+      }
+
+      if (this.fields.size > 0) {
+        const createSql = this.buildCreateTableSql();
+        if (this.debug) {
+          this.pushLine("Running: " + createSql);
+        }
+        await connection.execute(createSql);
+      }
+
+      for (const record of this.pendingRecords) {
+        const sql = this.buildInsertSql(record);
+        if (this.debug) {
+          this.pushLine("Running: " + sql);
+        }
+        await connection.execute(sql);
+      }
+    } finally {
+      await connection.end();
+    }
   }
 
   override doesRecordOutput(): boolean {
@@ -196,20 +436,37 @@ export class ToDb extends Operation {
     return `Usage: recs todb <options> [<files>]
    Dumps a stream of input records into a database.
 
+   Supports SQLite (default), PostgreSQL (--type pg), and MySQL (--type mysql).
+   PostgreSQL requires the 'pg' package. MySQL requires the 'mysql2' package.
+
 Arguments:
   --drop                Drop the table before create/insert
   --table <name>        Table name (default: recs)
   --debug               Print all executed SQL
   --key|-k <fields>     Fields to insert (name or name=SQL_TYPE)
   --dbfile <path>       Database file path (for SQLite)
-  --type <type>         Database type (sqlite)
+  --type <type>         Database type: sqlite (default), pg, mysql
+  --host <hostname>     Hostname for database connection (pg, mysql)
+  --port <port>         Port for database connection (pg, mysql)
+  --db <database>       Database name (pg, mysql)
+  --user <user>         Database user for authentication
+  --password <password> Database password for authentication
 
 Examples:
-   # Put all records into the recs table
+   # Put all records into the recs table (SQLite)
    recs todb --type sqlite --dbfile testDb --table recs
 
    # Specify fields and drop existing table
-   recs todb --dbfile testDb --drop --key status,description=TEXT --key user`;
+   recs todb --dbfile testDb --drop --key status,description=TEXT --key user
+
+   # Insert into PostgreSQL via Unix socket
+   recs todb --type pg --db mydb --table users
+
+   # Insert into PostgreSQL with host and credentials
+   recs todb --type pg --host db.example.com --port 5432 --db mydb --user admin --password secret
+
+   # Insert into MySQL
+   recs todb --type mysql --host localhost --db mydb --user root --table orders`;
   }
 }
 
@@ -226,7 +483,7 @@ export const documentation: CommandDoc = {
   category: "output",
   synopsis: "recs todb [options] [files...]",
   description:
-    "Dumps a stream of input records into a database. The record fields you want inserted should have the same keys as the column names in the database, and the records should be key-value pairs. This command will attempt to create the table if it is not already present.",
+    "Dumps a stream of input records into a database. The record fields you want inserted should have the same keys as the column names in the database, and the records should be key-value pairs. This command will attempt to create the table if it is not already present.\n\nSupports SQLite (default), PostgreSQL (--type pg), and MySQL (--type mysql).\n\nPostgreSQL requires the 'pg' package. MySQL requires the 'mysql2' package.",
   options: [
     {
       flags: ["--drop"],
@@ -261,17 +518,57 @@ export const documentation: CommandDoc = {
     {
       flags: ["--type"],
       argument: "<type>",
-      description: "Database type (sqlite).",
+      description: "Database type: sqlite (default), pg, mysql.",
+    },
+    {
+      flags: ["--host"],
+      argument: "<hostname>",
+      description:
+        "Hostname for database connection. For pg, omit to use Unix domain socket. Required for mysql.",
+    },
+    {
+      flags: ["--port"],
+      argument: "<port>",
+      description: "Port for database connection (pg, mysql).",
+    },
+    {
+      flags: ["--db", "--dbname"],
+      argument: "<database>",
+      description: "Database name. Required for pg and mysql.",
+    },
+    {
+      flags: ["--user"],
+      argument: "<user>",
+      description: "Database user for authentication.",
+    },
+    {
+      flags: ["--password"],
+      argument: "<password>",
+      description: "Database password for authentication.",
     },
   ],
   examples: [
     {
-      description: "Put all records into the recs table",
+      description: "Put all records into the recs table (SQLite)",
       command: "recs todb --type sqlite --dbfile testDb --table recs",
     },
     {
       description: "Specify fields and drop existing table",
       command: "recs todb --dbfile testDb --drop --key status,description=TEXT --key user",
+    },
+    {
+      description: "Insert into PostgreSQL via Unix socket",
+      command: "recs todb --type pg --db mydb --table users",
+    },
+    {
+      description: "Insert into PostgreSQL with credentials",
+      command:
+        "recs todb --type pg --host db.example.com --port 5432 --db mydb --user admin --password secret",
+    },
+    {
+      description: "Insert into MySQL",
+      command:
+        "recs todb --type mysql --host localhost --db mydb --user root --table orders",
     },
   ],
   seeAlso: ["fromdb"],

--- a/src/operations/transform/eval.ts
+++ b/src/operations/transform/eval.ts
@@ -9,9 +9,6 @@ import { createSnippetRunner, isJsLang, langOptionDef } from "../../snippets/ind
  * Evaluate a JS snippet on each record and output the result as a line.
  * This is NOT a record stream output—it prints raw text lines.
  *
- * When --lang is set to a non-JS language, the external runner modifies the
- * record and the modified record is output as a JSON line.
- *
  * Analogous to App::RecordStream::Operation::eval in Perl.
  */
 export class EvalOperation extends Operation {
@@ -81,7 +78,7 @@ export class EvalOperation extends Operation {
     let result = String(value ?? "");
 
     if (this.chomp) {
-      result = result.replace(/\n+$/, "");
+      result = result.replace(/\n$/, "");
     }
 
     this.pushLine(result);
@@ -97,7 +94,11 @@ export class EvalOperation extends Operation {
           continue;
         }
         if (result.record) {
-          this.pushLine(JSON.stringify(result.record));
+          let text = JSON.stringify(result.record);
+          if (this.chomp) {
+            text = text.replace(/\n$/, "");
+          }
+          this.pushLine(text);
         }
       }
     }
@@ -118,9 +119,7 @@ export const documentation: CommandDoc = {
     "Evaluate an expression on each record and print the result as a line " +
     "of text. This is NOT a record stream output -- it prints raw text lines. " +
     "The expression is evaluated with r set to the current Record object and " +
-    "line set to the current line number (starting at 1). " +
-    "When --lang is used with a non-JS language, the record is modified by " +
-    "the snippet and output as a JSON line.",
+    "line set to the current line number (starting at 1).",
   options: [
     {
       flags: ["--chomp"],

--- a/src/operations/transform/sort.ts
+++ b/src/operations/transform/sort.ts
@@ -68,7 +68,9 @@ export const documentation: CommandDoc = {
   description:
     "Sort records from input or from files. You may sort on a list of keys, " +
     "each key sorted lexically (alpha order) or numerically. The sort type " +
-    "may be prefixed with '-' to indicate decreasing order.",
+    "may be prefixed with '-' to indicate decreasing order. The sort type " +
+    "may be postfixed with '*' to sort the special value 'ALL' to the end " +
+    "(useful with collate --cube).",
   options: [
     {
       flags: ["--key", "-k"],
@@ -76,7 +78,8 @@ export const documentation: CommandDoc = {
         "Sort key specification. May be comma-separated, may be specified " +
         "multiple times. Each keyspec is a name or name=sortType. Sort type " +
         "may be lexical, numeric, nat, lex, n, or l. May be prefixed with " +
-        "'-' for decreasing order.",
+        "'-' for decreasing order. May be postfixed with '*' to sort the " +
+        "special value 'ALL' to the end.",
       argument: "<keyspec>",
     },
     {
@@ -96,6 +99,10 @@ export const documentation: CommandDoc = {
     {
       description: "Sort on decreasing size, then name",
       command: "recs sort --key size=-numeric --key name",
+    },
+    {
+      description: "Sort numerically, with 'ALL' values last",
+      command: "recs sort --key count=numeric*",
     },
   ],
   seeAlso: ["collate", "topn"],

--- a/src/types/woothee.d.ts
+++ b/src/types/woothee.d.ts
@@ -1,0 +1,16 @@
+declare module "woothee" {
+  interface WootheeResult {
+    name: string;
+    category: string;
+    os: string;
+    version: string;
+    vendor: string;
+    os_version: string;
+  }
+
+  function parse(ua: string): WootheeResult;
+  function isCrawler(ua: string): boolean;
+
+  export { parse, isCrawler };
+  export default { parse, isCrawler };
+}

--- a/tests/operations/input/fromapache.test.ts
+++ b/tests/operations/input/fromapache.test.ts
@@ -85,4 +85,42 @@ describe("FromApache", () => {
     );
     expect(result.length).toBe(0);
   });
+
+  test("--woothee parses user agent into ua_* fields", () => {
+    const result = runFromApache(["--woothee"], [combinedLine]);
+    expect(result.length).toBe(1);
+    const r = result[0]!;
+    // Basic fields still present
+    expect(r["rhost"]).toBe("192.168.0.1");
+    expect(r["agent"]).toBe("DoCoMo/2.0 P03B(c500;TB;W24H16)");
+    // Woothee-parsed fields
+    expect(r["ua_name"]).toBe("docomo");
+    expect(r["ua_category"]).toBe("mobilephone");
+    expect(r["ua_os"]).toBe("docomo");
+    expect(r["ua_version"]).toBe("P03B");
+    expect(r["ua_vendor"]).toBe("docomo");
+    expect(r["ua_os_version"]).toBe("UNKNOWN");
+  });
+
+  test("--woothee with desktop browser user agent", () => {
+    const line =
+      '10.0.0.1 - user [15/Mar/2024:12:00:00 +0000] "GET /index.html HTTP/1.1" 200 1234 "http://example.com" "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.111 Safari/537.36"';
+    const result = runFromApache(["--woothee"], [line]);
+    expect(result.length).toBe(1);
+    const r = result[0]!;
+    expect(r["ua_name"]).toBe("Chrome");
+    expect(r["ua_category"]).toBe("pc");
+    expect(r["ua_os"]).toBe("Windows 7");
+    expect(r["ua_vendor"]).toBe("Google");
+    expect(r["ua_version"]).toBe("47.0.2526.111");
+    expect(r["ua_os_version"]).toBe("NT 6.1");
+  });
+
+  test("without --woothee, no ua_* fields are added", () => {
+    const result = runFromApache([], [combinedLine]);
+    expect(result.length).toBe(1);
+    const r = result[0]!;
+    expect(r["ua_name"]).toBeUndefined();
+    expect(r["ua_category"]).toBeUndefined();
+  });
 });

--- a/tests/operations/input/fromcsv.test.ts
+++ b/tests/operations/input/fromcsv.test.ts
@@ -108,4 +108,29 @@ describe("FromCsv", () => {
     );
     expect(result).toEqual([{ "0": 'foo "bar" bat' }]);
   });
+
+  test("parse error in strict mode (middle of file)", () => {
+    const collector = new CollectorReceiver();
+    const op = new FromCsv(collector);
+    op.init(["--strict"]);
+    op.updateCurrentFilename("test.csv");
+    expect(() => {
+      op.parseContent('a,b\n"unclosed\nc,d\n');
+    }).toThrow(/fromcsv: parse error:.*position 5.*line 2.*file test\.csv/);
+  });
+
+  test("parse error in strict mode (last line)", () => {
+    const collector = new CollectorReceiver();
+    const op = new FromCsv(collector);
+    op.init(["--strict"]);
+    op.updateCurrentFilename("test.csv");
+    expect(() => {
+      op.parseContent('a,b\nc,d\n"unclosed\n');
+    }).toThrow(/fromcsv: parse error:.*position 9.*line 3.*file test\.csv/);
+  });
+
+  test("embedded newlines in quoted fields", () => {
+    const result = runFromCsv([], '"hello\nworld",bar\n');
+    expect(result).toEqual([{ "0": "hello\nworld", "1": "bar" }]);
+  });
 });

--- a/tests/operations/input/fromps.test.ts
+++ b/tests/operations/input/fromps.test.ts
@@ -36,6 +36,90 @@ describe("FromPs", () => {
     ]);
   });
 
+  test("default UID conversion converts uid field to username", () => {
+    const collector = new CollectorReceiver();
+    const op = new FromPs(collector);
+    op.setProcessTable(new MockTable());
+    // Don't call setUidConverter — let the default kick in
+    op.init([]);
+    op.finish();
+
+    const result = collector.records.map((r) => r.toJSON());
+    // Default converter parses /etc/passwd; UID 1003 may or may not resolve.
+    // But the uid field should be a string (either a username or the UID as string).
+    for (const rec of result) {
+      expect(typeof rec["uid"]).toBe("string");
+    }
+    // All records should have same uid since they all have uid "1003"
+    const uids = new Set(result.map((r) => r["uid"]));
+    expect(uids.size).toBe(1);
+  });
+
+  test("--no-uid-convert flag keeps uid as original value", () => {
+    const collector = new CollectorReceiver();
+    const op = new FromPs(collector);
+    op.setProcessTable(new MockTable());
+    op.init(["--no-uid-convert"]);
+    op.finish();
+
+    const result = collector.records.map((r) => r.toJSON());
+    expect(result).toEqual([
+      { uid: "1003", pid: 1, ppid: 0 },
+      { uid: "1003", pid: 2, ppid: 1 },
+      { uid: "1003", pid: 3, ppid: 0 },
+      { uid: "1003", pid: 4, ppid: 2 },
+    ]);
+  });
+
+  test("euid field is also converted by default", () => {
+    class MockTableWithEuid implements ProcessTableSource {
+      getProcesses(): JsonObject[] {
+        return [
+          { uid: "1003", euid: "1003", pid: 1 },
+        ];
+      }
+      getFields(): string[] {
+        return ["uid", "euid", "pid"];
+      }
+    }
+
+    const collector = new CollectorReceiver();
+    const op = new FromPs(collector);
+    op.setProcessTable(new MockTableWithEuid());
+    op.setUidConverter((_uid: JsonValue) => "bernard");
+    op.init([]);
+    op.finish();
+
+    const result = collector.records.map((r) => r.toJSON());
+    expect(result).toEqual([
+      { uid: "bernard", euid: "bernard", pid: 1 },
+    ]);
+  });
+
+  test("euid field is not converted with --no-uid-convert", () => {
+    class MockTableWithEuid implements ProcessTableSource {
+      getProcesses(): JsonObject[] {
+        return [
+          { uid: "1003", euid: "1003", pid: 1 },
+        ];
+      }
+      getFields(): string[] {
+        return ["uid", "euid", "pid"];
+      }
+    }
+
+    const collector = new CollectorReceiver();
+    const op = new FromPs(collector);
+    op.setProcessTable(new MockTableWithEuid());
+    op.init(["--no-uid-convert"]);
+    op.finish();
+
+    const result = collector.records.map((r) => r.toJSON());
+    expect(result).toEqual([
+      { uid: "1003", euid: "1003", pid: 1 },
+    ]);
+  });
+
   test("wantsInput returns false", () => {
     const op = new FromPs();
     op.setProcessTable(new MockTable());

--- a/tests/operations/input/fromtcpdump.test.ts
+++ b/tests/operations/input/fromtcpdump.test.ts
@@ -31,17 +31,410 @@ describe("FromTcpdump", () => {
     try {
       op.finish();
       const records = collector.records.map((r) => r.toJSON());
-      // Should produce some records
-      expect(records.length).toBeGreaterThan(0);
+      // Should produce 2 records (one DNS query, one DNS response)
+      expect(records.length).toBe(2);
 
       // Each record should have file and type fields
       for (const r of records) {
         expect(r["file"]).toBe("tests/fixtures/test-capture1.pcap");
-        expect(r["type"]).toBeDefined();
+        expect(r["type"]).toBe("udp");
       }
+
+      // First record: DNS query
+      const query = records[0]!;
+      expect(query["timestamp"]).toBe("1294004869.088858");
+      expect(query["ethernet"]).toEqual({
+        src_mac: "08:00:27:e0:fd:58",
+        dest_mac: "52:54:00:12:35:02",
+      });
+      expect(query["length"]).toBe(84);
+      const queryIp = query["ip"] as Record<string, unknown>;
+      expect(queryIp["src_ip"]).toBe("10.0.2.15");
+      expect(queryIp["dest_ip"]).toBe("10.0.0.1");
+      expect(queryIp["ttl"]).toBe(64);
+      expect(queryIp["id"]).toBe(15208);
+      expect(queryIp["proto"]).toBe(17);
+      const queryUdp = query["udp"] as Record<string, unknown>;
+      expect(queryUdp["src_port"]).toBe(46578);
+      expect(queryUdp["dest_port"]).toBe(53);
+
+      // DNS parsed
+      const queryDns = query["dns"] as Record<string, unknown>;
+      expect(queryDns["id"]).toBe(3930);
+      expect(queryDns["qr"]).toBe(0);
+
+      // Second record: DNS response
+      const response = records[1]!;
+      expect(response["timestamp"]).toBe("1294004869.160748");
+      const respDns = response["dns"] as Record<string, unknown>;
+      expect(respDns["id"]).toBe(3930);
+      expect(respDns["qr"]).toBe(1);
+      const respAnswers = respDns["answer"] as Array<Record<string, unknown>>;
+      expect(respAnswers.length).toBe(6);
+      expect(respAnswers[0]!["data"]).toBe("63.251.171.81");
     } catch (e) {
       // tcpdump may not have permission to read pcap files
       console.log("tcpdump test skipped due to error:", (e as Error).message);
     }
+  });
+
+  describe("parsePacket", () => {
+    function parse(lines: string[], file = "test.pcap") {
+      const op = new FromTcpdump();
+      return op.parsePacket(lines, file);
+    }
+
+    describe("ethernet MAC addresses", () => {
+      test("parses src and dest MAC from -e output", () => {
+        const result = parse([
+          "1609459200.000000 aa:bb:cc:dd:ee:01 > ff:ee:dd:cc:bb:02, ethertype IPv4 (0x0800), length 84: (tos 0x0, ttl 64, id 15208, offset 0, flags [none], proto UDP (17), length 70)",
+          "    10.0.2.15.46578 > 10.0.0.1.53: 3930+ A? example.com. (42)",
+        ]);
+        expect(result!["ethernet"]).toEqual({
+          src_mac: "aa:bb:cc:dd:ee:01",
+          dest_mac: "ff:ee:dd:cc:bb:02",
+        });
+      });
+
+      test("parses broadcast MAC", () => {
+        const result = parse([
+          "1609459200.000000 aa:bb:cc:dd:ee:01 > ff:ff:ff:ff:ff:ff, ethertype ARP (0x0806), length 42: Request who-has 10.0.0.1 tell 10.0.2.15, length 28",
+        ]);
+        expect(result!["ethernet"]).toEqual({
+          src_mac: "aa:bb:cc:dd:ee:01",
+          dest_mac: "ff:ff:ff:ff:ff:ff",
+        });
+      });
+    });
+
+    describe("IP packet details", () => {
+      test("parses tos, ttl, id, offset, proto, len", () => {
+        const result = parse([
+          "1609459200.000000 aa:bb:cc:dd:ee:01 > ff:ee:dd:cc:bb:02, ethertype IPv4 (0x0800), length 84: (tos 0x10, ttl 63, id 54321, offset 0, flags [none], proto UDP (17), length 70)",
+          "    10.0.2.15.46578 > 10.0.0.1.53: 3930+ A? example.com. (42)",
+        ]);
+        const ip = result!["ip"] as Record<string, unknown>;
+        expect(ip["tos"]).toBe(0x10);
+        expect(ip["ttl"]).toBe(63);
+        expect(ip["id"]).toBe(54321);
+        expect(ip["offset"]).toBe(0);
+        expect(ip["proto"]).toBe(17);
+        expect(ip["len"]).toBe(70);
+      });
+
+      test("parses frame length", () => {
+        const result = parse([
+          "1609459200.000000 aa:bb:cc:dd:ee:01 > ff:ee:dd:cc:bb:02, ethertype IPv4 (0x0800), length 84: (tos 0x0, ttl 64, id 15208, offset 0, flags [none], proto UDP (17), length 70)",
+          "    10.0.2.15.46578 > 10.0.0.1.53: 3930+ A? example.com. (42)",
+        ]);
+        expect(result!["length"]).toBe(84);
+      });
+    });
+
+    describe("IP flags", () => {
+      test("parses DF flag", () => {
+        const result = parse([
+          "1609459200.000000 aa:bb:cc:dd:ee:01 > ff:ee:dd:cc:bb:02, ethertype IPv4 (0x0800), length 74: (tos 0x0, ttl 64, id 12345, offset 0, flags [DF], proto TCP (6), length 60)",
+          "    10.0.0.1.54321 > 93.184.216.34.80: Flags [S], seq 1234567890, win 65535, length 0",
+        ]);
+        const ip = result!["ip"] as Record<string, unknown>;
+        const flags = ip["flags"] as Record<string, unknown>;
+        expect(flags["dont_fragment"]).toBe(1);
+        expect(flags["more_fragments"]).toBeUndefined();
+      });
+
+      test("parses MF flag", () => {
+        const result = parse([
+          "1609459200.000000 aa:bb:cc:dd:ee:01 > ff:ee:dd:cc:bb:02, ethertype IPv4 (0x0800), length 1500: (tos 0x0, ttl 64, id 12345, offset 0, flags [MF], proto TCP (6), length 1480)",
+          "    10.0.0.1.54321 > 93.184.216.34.80: Flags [.], seq 1:1001, ack 1, win 65535, length 1000",
+        ]);
+        const ip = result!["ip"] as Record<string, unknown>;
+        const flags = ip["flags"] as Record<string, unknown>;
+        expect(flags["more_fragments"]).toBe(1);
+        expect(flags["dont_fragment"]).toBeUndefined();
+      });
+
+      test("parses no flags as empty object", () => {
+        const result = parse([
+          "1609459200.000000 aa:bb:cc:dd:ee:01 > ff:ee:dd:cc:bb:02, ethertype IPv4 (0x0800), length 84: (tos 0x0, ttl 64, id 15208, offset 0, flags [none], proto UDP (17), length 70)",
+          "    10.0.2.15.46578 > 10.0.0.1.53: 3930+ A? example.com. (42)",
+        ]);
+        const ip = result!["ip"] as Record<string, unknown>;
+        expect(ip["flags"]).toEqual({});
+      });
+    });
+
+    describe("TCP packet details", () => {
+      test("parses SYN packet with seq, win, cksum, options", () => {
+        const result = parse([
+          "1609459200.000000 aa:bb:cc:dd:ee:01 > ff:ee:dd:cc:bb:02, ethertype IPv4 (0x0800), length 74: (tos 0x0, ttl 64, id 12345, offset 0, flags [DF], proto TCP (6), length 60)",
+          "    10.0.0.1.54321 > 93.184.216.34.80: Flags [S], cksum 0xa92f (correct), seq 1234567890, win 65535, options [mss 1460,sackOK,TS val 12345 ecr 0,nop,wscale 7], length 0",
+        ]);
+        expect(result!["type"]).toBe("tcp");
+        const tcp = result!["tcp"] as Record<string, unknown>;
+        expect(tcp["src_port"]).toBe(54321);
+        expect(tcp["dest_port"]).toBe(80);
+        expect(tcp["seq"]).toBe(1234567890);
+        expect(tcp["seq_end"]).toBeUndefined();
+        expect(tcp["win"]).toBe(65535);
+        expect(tcp["cksum"]).toBe(0xa92f);
+        expect(tcp["options"]).toBe(
+          "mss 1460,sackOK,TS val 12345 ecr 0,nop,wscale 7"
+        );
+        expect(tcp["data_length"]).toBe(0);
+        const flags = tcp["flags"] as Record<string, unknown>;
+        expect(flags["SYN"]).toBe(1);
+        expect(flags["ACK"]).toBeUndefined();
+      });
+
+      test("parses data packet with seq range and ack", () => {
+        const result = parse([
+          "1609459200.100000 aa:bb:cc:dd:ee:01 > ff:ee:dd:cc:bb:02, ethertype IPv4 (0x0800), length 174: (tos 0x10, ttl 63, id 12346, offset 0, flags [DF], proto TCP (6), length 160)",
+          "    10.0.0.1.54321 > 93.184.216.34.80: Flags [P.], cksum 0xb3f4 (correct), seq 1:101, ack 1, win 65535, options [nop,nop,TS val 12346 ecr 54321], length 100",
+        ]);
+        const tcp = result!["tcp"] as Record<string, unknown>;
+        expect(tcp["seq"]).toBe(1);
+        expect(tcp["seq_end"]).toBe(101);
+        expect(tcp["ack"]).toBe(1);
+        expect(tcp["data_length"]).toBe(100);
+        const flags = tcp["flags"] as Record<string, unknown>;
+        expect(flags["PSH"]).toBe(1);
+        expect(flags["ACK"]).toBe(1);
+      });
+
+      test("parses FIN and RST flags", () => {
+        const result = parse([
+          "1609459200.000000 aa:bb:cc:dd:ee:01 > ff:ee:dd:cc:bb:02, ethertype IPv4 (0x0800), length 54: (tos 0x0, ttl 64, id 12348, offset 0, flags [DF], proto TCP (6), length 40)",
+          "    10.0.0.1.54321 > 93.184.216.34.80: Flags [FR.], seq 500, ack 600, win 0, length 0",
+        ]);
+        const tcp = result!["tcp"] as Record<string, unknown>;
+        const flags = tcp["flags"] as Record<string, unknown>;
+        expect(flags["FIN"]).toBe(1);
+        expect(flags["RST"]).toBe(1);
+        expect(flags["ACK"]).toBe(1);
+      });
+    });
+
+    describe("missing TCP flags: URG, ECE, CWR", () => {
+      test("parses URG flag", () => {
+        const result = parse([
+          "1609459200.000000 aa:bb:cc:dd:ee:01 > ff:ee:dd:cc:bb:02, ethertype IPv4 (0x0800), length 74: (tos 0x0, ttl 64, id 12347, offset 0, flags [none], proto TCP (6), length 60)",
+          "    10.0.0.1.54321 > 93.184.216.34.80: Flags [U.], seq 100, ack 200, win 32768, length 0",
+        ]);
+        const tcp = result!["tcp"] as Record<string, unknown>;
+        const flags = tcp["flags"] as Record<string, unknown>;
+        expect(flags["URG"]).toBe(1);
+        expect(flags["ACK"]).toBe(1);
+      });
+
+      test("parses ECE flag", () => {
+        const result = parse([
+          "1609459200.000000 aa:bb:cc:dd:ee:01 > ff:ee:dd:cc:bb:02, ethertype IPv4 (0x0800), length 74: (tos 0x0, ttl 64, id 12347, offset 0, flags [none], proto TCP (6), length 60)",
+          "    10.0.0.1.54321 > 93.184.216.34.80: Flags [SE.], seq 100, ack 200, win 32768, length 0",
+        ]);
+        const tcp = result!["tcp"] as Record<string, unknown>;
+        const flags = tcp["flags"] as Record<string, unknown>;
+        expect(flags["SYN"]).toBe(1);
+        expect(flags["ECE"]).toBe(1);
+        expect(flags["ACK"]).toBe(1);
+      });
+
+      test("parses CWR flag", () => {
+        const result = parse([
+          "1609459200.000000 aa:bb:cc:dd:ee:01 > ff:ee:dd:cc:bb:02, ethertype IPv4 (0x0800), length 74: (tos 0x0, ttl 64, id 12347, offset 0, flags [none], proto TCP (6), length 60)",
+          "    10.0.0.1.54321 > 93.184.216.34.80: Flags [W.], seq 100, ack 200, win 32768, length 0",
+        ]);
+        const tcp = result!["tcp"] as Record<string, unknown>;
+        const flags = tcp["flags"] as Record<string, unknown>;
+        expect(flags["CWR"]).toBe(1);
+        expect(flags["ACK"]).toBe(1);
+      });
+
+      test("parses all flags together", () => {
+        const result = parse([
+          "1609459200.000000 aa:bb:cc:dd:ee:01 > ff:ee:dd:cc:bb:02, ethertype IPv4 (0x0800), length 74: (tos 0x0, ttl 64, id 12347, offset 0, flags [none], proto TCP (6), length 60)",
+          "    10.0.0.1.54321 > 93.184.216.34.80: Flags [SFRPUEW.], seq 100, ack 200, win 32768, length 0",
+        ]);
+        const tcp = result!["tcp"] as Record<string, unknown>;
+        const flags = tcp["flags"] as Record<string, unknown>;
+        expect(flags["SYN"]).toBe(1);
+        expect(flags["FIN"]).toBe(1);
+        expect(flags["RST"]).toBe(1);
+        expect(flags["PSH"]).toBe(1);
+        expect(flags["URG"]).toBe(1);
+        expect(flags["ECE"]).toBe(1);
+        expect(flags["CWR"]).toBe(1);
+        expect(flags["ACK"]).toBe(1);
+      });
+    });
+
+    describe("UDP packet details", () => {
+      test("parses UDP checksum from bad cksum format", () => {
+        const result = parse([
+          "1609459200.000000 aa:bb:cc:dd:ee:01 > ff:ee:dd:cc:bb:02, ethertype IPv4 (0x0800), length 84: (tos 0x0, ttl 64, id 15208, offset 0, flags [none], proto UDP (17), length 70)",
+          "    10.0.2.15.46578 > 10.0.0.1.53: [bad udp cksum 0x1653 -> 0x44b0!] 3930+ A? example.com. (42)",
+        ]);
+        expect(result!["type"]).toBe("udp");
+        const udp = result!["udp"] as Record<string, unknown>;
+        expect(udp["cksum"]).toBe(0x1653);
+      });
+
+      test("computes UDP length from data length", () => {
+        const result = parse([
+          "1609459200.000000 aa:bb:cc:dd:ee:01 > ff:ee:dd:cc:bb:02, ethertype IPv4 (0x0800), length 84: (tos 0x0, ttl 64, id 15208, offset 0, flags [none], proto UDP (17), length 70)",
+          "    10.0.2.15.46578 > 10.0.0.1.53: [bad udp cksum 0x1653 -> 0x44b0!] 3930+ A? example.com. (42)",
+        ]);
+        const udp = result!["udp"] as Record<string, unknown>;
+        // UDP length = data length (42) + 8 byte header = 50
+        expect(udp["len"]).toBe(50);
+      });
+
+      test("parses UDP ports", () => {
+        const result = parse([
+          "1609459200.000000 aa:bb:cc:dd:ee:01 > ff:ee:dd:cc:bb:02, ethertype IPv4 (0x0800), length 100: (tos 0x0, ttl 64, id 15208, offset 0, flags [none], proto UDP (17), length 86)",
+          "    192.168.1.100.12345 > 8.8.8.8.53: [udp sum ok] 999+ A? example.org. (30)",
+        ]);
+        const udp = result!["udp"] as Record<string, unknown>;
+        expect(udp["src_port"]).toBe(12345);
+        expect(udp["dest_port"]).toBe(53);
+      });
+    });
+
+    describe("DNS packet parsing", () => {
+      test("parses DNS query", () => {
+        const result = parse([
+          "1609459200.000000 aa:bb:cc:dd:ee:01 > ff:ee:dd:cc:bb:02, ethertype IPv4 (0x0800), length 84: (tos 0x0, ttl 64, id 15208, offset 0, flags [none], proto UDP (17), length 70)",
+          "    10.0.2.15.46578 > 10.0.0.1.53: [bad udp cksum 0x1653 -> 0x44b0!] 3930+ A? blog.benjaminbernard.com. (42)",
+        ]);
+        const dns = result!["dns"] as Record<string, unknown>;
+        expect(dns["id"]).toBe(3930);
+        expect(dns["qr"]).toBe(0);
+        const question = dns["question"] as Array<Record<string, unknown>>;
+        expect(question[0]!["qname"]).toBe("blog.benjaminbernard.com");
+        expect(question[0]!["qtype"]).toBe("A");
+        expect(dns["answer"]).toEqual([]);
+      });
+
+      test("parses DNS response with answers", () => {
+        const result = parse([
+          "1609459200.000000 ff:ee:dd:cc:bb:02 > aa:bb:cc:dd:ee:01, ethertype IPv4 (0x0800), length 180: (tos 0x0, ttl 64, id 2525, offset 0, flags [none], proto UDP (17), length 166)",
+          "    10.0.0.1.53 > 10.0.2.15.46578: [udp sum ok] 3930 q: A? blog.benjaminbernard.com. 6/0/0 blog.benjaminbernard.com. A 63.251.171.81, blog.benjaminbernard.com. A 69.25.27.170, blog.benjaminbernard.com. A 63.251.171.80, blog.benjaminbernard.com. A 69.25.27.173, blog.benjaminbernard.com. A 66.150.161.141, blog.benjaminbernard.com. A 66.150.161.140 (138)",
+        ]);
+        const dns = result!["dns"] as Record<string, unknown>;
+        expect(dns["id"]).toBe(3930);
+        expect(dns["qr"]).toBe(1);
+        const question = dns["question"] as Array<Record<string, unknown>>;
+        expect(question[0]!["qname"]).toBe("blog.benjaminbernard.com");
+        expect(question[0]!["qtype"]).toBe("A");
+        const counts = dns["counts"] as Record<string, unknown>;
+        expect(counts["answer"]).toBe(6);
+        expect(counts["authority"]).toBe(0);
+        expect(counts["additional"]).toBe(0);
+        const answers = dns["answer"] as Array<Record<string, unknown>>;
+        expect(answers.length).toBe(6);
+        expect(answers[0]!["name"]).toBe("blog.benjaminbernard.com");
+        expect(answers[0]!["type"]).toBe("A");
+        expect(answers[0]!["data"]).toBe("63.251.171.81");
+        expect(answers[5]!["data"]).toBe("66.150.161.140");
+      });
+
+      test("does not parse DNS for non-port-53 packets", () => {
+        const result = parse([
+          "1609459200.000000 aa:bb:cc:dd:ee:01 > ff:ee:dd:cc:bb:02, ethertype IPv4 (0x0800), length 100: (tos 0x0, ttl 64, id 15208, offset 0, flags [none], proto UDP (17), length 86)",
+          "    192.168.1.100.12345 > 8.8.8.8.443: [udp sum ok] some data (30)",
+        ]);
+        expect(result!["dns"]).toBeUndefined();
+      });
+    });
+
+    describe("ARP packet parsing", () => {
+      test("parses ARP request", () => {
+        const result = parse([
+          "1609459200.000000 aa:bb:cc:dd:ee:01 > ff:ff:ff:ff:ff:ff, ethertype ARP (0x0806), length 42: Request who-has 10.0.0.1 tell 10.0.2.15, length 28",
+        ]);
+        expect(result!["type"]).toBe("arp");
+        const arp = result!["arp"] as Record<string, unknown>;
+        expect(arp["opcode"]).toBe("ARP_REQUEST");
+        expect(arp["target_ip"]).toBe("10.0.0.1");
+        expect(arp["sender_ip"]).toBe("10.0.2.15");
+      });
+
+      test("parses ARP reply", () => {
+        const result = parse([
+          "1609459200.000000 ff:ee:dd:cc:bb:02 > aa:bb:cc:dd:ee:01, ethertype ARP (0x0806), length 42: Reply 10.0.0.1 is-at ff:ee:dd:cc:bb:02, length 28",
+        ]);
+        expect(result!["type"]).toBe("arp");
+        const arp = result!["arp"] as Record<string, unknown>;
+        expect(arp["opcode"]).toBe("ARP_REPLY");
+        expect(arp["sender_ip"]).toBe("10.0.0.1");
+        expect(arp["sender_mac"]).toBe("ff:ee:dd:cc:bb:02");
+      });
+
+      test("parses ethernet MAC addresses on ARP packets", () => {
+        const result = parse([
+          "1609459200.000000 aa:bb:cc:dd:ee:01 > ff:ff:ff:ff:ff:ff, ethertype ARP (0x0806), length 42: Request who-has 10.0.0.1 tell 10.0.2.15, length 28",
+        ]);
+        expect(result!["ethernet"]).toEqual({
+          src_mac: "aa:bb:cc:dd:ee:01",
+          dest_mac: "ff:ff:ff:ff:ff:ff",
+        });
+      });
+
+      test("parses frame length for ARP packets", () => {
+        const result = parse([
+          "1609459200.000000 aa:bb:cc:dd:ee:01 > ff:ff:ff:ff:ff:ff, ethertype ARP (0x0806), length 42: Request who-has 10.0.0.1 tell 10.0.2.15, length 28",
+        ]);
+        expect(result!["length"]).toBe(42);
+      });
+    });
+
+    describe("ARP with verbose detail", () => {
+      test("parses ARP request with Ethernet/IPv4 detail", () => {
+        const result = parse([
+          "1609459200.000000 aa:bb:cc:dd:ee:01 > ff:ff:ff:ff:ff:ff, ethertype ARP (0x0806), length 42: Ethernet (len 6), IPv4 (len 4), Request who-has 10.0.0.1 tell 10.0.2.15, length 28",
+        ]);
+        expect(result!["type"]).toBe("arp");
+        const arp = result!["arp"] as Record<string, unknown>;
+        expect(arp["opcode"]).toBe("ARP_REQUEST");
+        expect(arp["target_ip"]).toBe("10.0.0.1");
+        expect(arp["sender_ip"]).toBe("10.0.2.15");
+      });
+    });
+
+    describe("timestamp parsing", () => {
+      test("parses timestamp", () => {
+        const result = parse([
+          "1609459200.123456 aa:bb:cc:dd:ee:01 > ff:ee:dd:cc:bb:02, ethertype IPv4 (0x0800), length 84: (tos 0x0, ttl 64, id 15208, offset 0, flags [none], proto UDP (17), length 70)",
+          "    10.0.2.15.46578 > 10.0.0.1.53: 3930+ A? example.com. (42)",
+        ]);
+        expect(result!["timestamp"]).toBe("1609459200.123456");
+      });
+    });
+
+    describe("file field", () => {
+      test("includes the file name", () => {
+        const result = parse(
+          [
+            "1609459200.000000 aa:bb:cc:dd:ee:01 > ff:ee:dd:cc:bb:02, ethertype IPv4 (0x0800), length 84: (tos 0x0, ttl 64, id 15208, offset 0, flags [none], proto UDP (17), length 70)",
+            "    10.0.2.15.46578 > 10.0.0.1.53: 3930+ A? example.com. (42)",
+          ],
+          "my-capture.pcap"
+        );
+        expect(result!["file"]).toBe("my-capture.pcap");
+      });
+    });
+
+    describe("unknown/ethernet packets", () => {
+      test("labels unknown ethertype as ethernet", () => {
+        const result = parse([
+          "1609459200.000000 aa:bb:cc:dd:ee:01 > ff:ee:dd:cc:bb:02, ethertype Unknown (0x9999), length 60: some data",
+        ]);
+        expect(result!["type"]).toBe("ethernet");
+        expect(result!["ethernet"]).toEqual({
+          src_mac: "aa:bb:cc:dd:ee:01",
+          dest_mac: "ff:ee:dd:cc:bb:02",
+        });
+      });
+    });
   });
 });

--- a/tests/operations/input/fromxml.test.ts
+++ b/tests/operations/input/fromxml.test.ts
@@ -83,4 +83,53 @@ describe("FromXml", () => {
     expect(result[0]!["name"]).toBe("a");
     expect(result[1]!["name"]).toBe("b");
   });
+
+  test("element deduplication", () => {
+    // Specifying the same element twice should deduplicate and produce
+    // the same results as specifying it once
+    const resultDuplicated = runFromXml([
+      "--element",
+      "server",
+      "--element",
+      "server",
+      "file:tests/fixtures/xml1",
+    ]);
+
+    const resultSingle = runFromXml([
+      "--element",
+      "server",
+      "file:tests/fixtures/xml1",
+    ]);
+
+    expect(resultDuplicated.length).toBe(3);
+    expect(resultDuplicated).toEqual(resultSingle);
+  });
+
+  test("comma-separated element syntax", () => {
+    // --element "server,inner" should match both <server> and <inner> elements,
+    // equivalent to --element server --element inner
+    const resultComma = runFromXml([
+      "--element",
+      "server,inner",
+      "--nested",
+      "file:tests/fixtures/xml1",
+    ]);
+
+    const resultSeparate = runFromXml([
+      "--element",
+      "server",
+      "--element",
+      "inner",
+      "--nested",
+      "file:tests/fixtures/xml1",
+    ]);
+
+    expect(resultComma).toEqual(resultSeparate);
+
+    // Both should have an "element" field since multiple elements are specified
+    for (const record of resultComma) {
+      expect(record["element"]).toBeDefined();
+      expect(["server", "inner"]).toContain(record["element"] as string);
+    }
+  });
 });

--- a/tests/operations/output/todb.test.ts
+++ b/tests/operations/output/todb.test.ts
@@ -83,4 +83,180 @@ describe("ToDb", () => {
     // Single quotes should be properly escaped
     expect(output).toContain("O''Brien");
   });
+
+  describe("multi-DB option parsing", () => {
+    test("--type pg sets dbType to pg", () => {
+      const collector = new LineCollector();
+      const op = new ToDb(collector);
+      // pg requires --db, so provide it (won't actually connect)
+      expect(() => op.init(["--type", "pg", "--db", "testdb"])).not.toThrow();
+      expect(op.dbType).toBe("pg");
+      expect(op.dbName).toBe("testdb");
+    });
+
+    test("--type postgres normalizes to pg", () => {
+      const collector = new LineCollector();
+      const op = new ToDb(collector);
+      expect(() => op.init(["--type", "postgres", "--db", "testdb"])).not.toThrow();
+      expect(op.dbType).toBe("pg");
+    });
+
+    test("--type pg requires --db", () => {
+      const collector = new LineCollector();
+      const op = new ToDb(collector);
+      expect(() => op.init(["--type", "pg"])).toThrow("--db is required for PostgreSQL");
+    });
+
+    test("--type mysql requires --host and --db", () => {
+      const collector = new LineCollector();
+      const op = new ToDb(collector);
+      expect(() => op.init(["--type", "mysql"])).toThrow("--host and --db are required for MySQL");
+    });
+
+    test("--type mysql with --db but no --host throws", () => {
+      const collector = new LineCollector();
+      const op = new ToDb(collector);
+      expect(() => op.init(["--type", "mysql", "--db", "testdb"])).toThrow("--host and --db are required for MySQL");
+    });
+
+    test("--type mysql accepts required options", () => {
+      const collector = new LineCollector();
+      const op = new ToDb(collector);
+      expect(() => op.init(["--type", "mysql", "--host", "localhost", "--db", "testdb"])).not.toThrow();
+      expect(op.dbType).toBe("mysql");
+      expect(op.host).toBe("localhost");
+      expect(op.dbName).toBe("testdb");
+    });
+
+    test("parses all connection options", () => {
+      const collector = new LineCollector();
+      const op = new ToDb(collector);
+      op.init([
+        "--type", "pg",
+        "--host", "db.example.com",
+        "--port", "5432",
+        "--db", "mydb",
+        "--user", "admin",
+        "--password", "secret",
+        "--table", "users",
+      ]);
+
+      expect(op.dbType).toBe("pg");
+      expect(op.host).toBe("db.example.com");
+      expect(op.port).toBe("5432");
+      expect(op.dbName).toBe("mydb");
+      expect(op.user).toBe("admin");
+      expect(op.password).toBe("secret");
+      expect(op.tableName).toBe("users");
+    });
+
+    test("--dbname is alias for --db", () => {
+      const collector = new LineCollector();
+      const op = new ToDb(collector);
+      op.init(["--type", "pg", "--dbname", "testdb"]);
+      expect(op.dbName).toBe("testdb");
+    });
+
+    test("defaults to sqlite when no --type specified", () => {
+      const collector = new LineCollector();
+      const op = new ToDb(collector);
+      op.init(["--dbfile", ":memory:"]);
+      expect(op.dbType).toBe("sqlite");
+    });
+
+    test("sqlite defaults dbfile to :memory:", () => {
+      const collector = new LineCollector();
+      const op = new ToDb(collector);
+      op.init([]);
+      expect(op.dbFile).toBe(":memory:");
+    });
+
+    test("pg buffers records for async flush", () => {
+      const collector = new LineCollector();
+      const op = new ToDb(collector);
+      op.init(["--type", "pg", "--db", "testdb"]);
+
+      op.acceptRecord(new Record({ name: "Alice" }));
+      op.acceptRecord(new Record({ name: "Bob" }));
+
+      expect(op.pendingRecords.length).toBe(2);
+      // db should not be initialized for pg (it's async)
+      expect(op.db).toBeNull();
+    });
+
+    test("mysql buffers records for async flush", () => {
+      const collector = new LineCollector();
+      const op = new ToDb(collector);
+      op.init(["--type", "mysql", "--host", "localhost", "--db", "testdb"]);
+
+      op.acceptRecord(new Record({ name: "Alice" }));
+      expect(op.pendingRecords.length).toBe(1);
+      expect(op.db).toBeNull();
+    });
+
+    test("unsupported db type throws on finish", async () => {
+      const collector = new LineCollector();
+      const op = new ToDb(collector);
+      // Manually set an unsupported type after init to bypass validation
+      op.init(["--dbfile", ":memory:"]);
+      op.dbType = "oracle";
+      op.pendingRecords.push(new Record({ x: 1 }));
+
+      try {
+        await op.streamDoneAsync();
+        expect(true).toBe(false); // Should not reach here
+      } catch (e: unknown) {
+        expect((e as Error).message).toContain("not supported");
+      }
+    });
+  });
+
+  describe("SQL generation for different DB types", () => {
+    test("sqlite uses AUTOINCREMENT in CREATE TABLE", () => {
+      const collector = new LineCollector();
+      const op = new ToDb(collector);
+      op.init(["--dbfile", ":memory:", "--debug", "--key", "name"]);
+
+      op.acceptRecord(new Record({ name: "Alice" }));
+      op.finish();
+
+      const output = collector.output();
+      expect(output).toContain("AUTOINCREMENT");
+      expect(output).not.toContain("AUTO_INCREMENT");
+    });
+
+    test("pg uses GENERATED ALWAYS AS IDENTITY in CREATE TABLE", () => {
+      const collector = new LineCollector();
+      const op = new ToDb(collector);
+      op.init(["--type", "pg", "--db", "testdb", "--key", "name"]);
+
+      // Manually test buildCreateTableSql without connecting
+      const sql = op.buildCreateTableSql();
+      expect(sql).toContain("GENERATED ALWAYS AS IDENTITY");
+      expect(sql).not.toContain("AUTOINCREMENT");
+    });
+
+    test("mysql uses AUTO_INCREMENT in CREATE TABLE", () => {
+      const collector = new LineCollector();
+      const op = new ToDb(collector);
+      op.init(["--type", "mysql", "--host", "localhost", "--db", "testdb", "--key", "name"]);
+
+      const sql = op.buildCreateTableSql();
+      expect(sql).toContain("AUTO_INCREMENT");
+      expect(sql).not.toContain("AUTOINCREMENT");
+    });
+
+    test("buildInsertSql generates correct SQL", () => {
+      const collector = new LineCollector();
+      const op = new ToDb(collector);
+      op.init(["--type", "pg", "--db", "testdb", "--key", "name,age=INTEGER"]);
+
+      const sql = op.buildInsertSql(new Record({ name: "Alice", age: 30 }));
+      expect(sql).toContain('INSERT INTO "recs"');
+      expect(sql).toContain('"name"');
+      expect(sql).toContain('"age"');
+      expect(sql).toContain("'Alice'");
+      expect(sql).toContain("'30'");
+    });
+  });
 });

--- a/tests/operations/output/toptable.test.ts
+++ b/tests/operations/output/toptable.test.ts
@@ -1,6 +1,26 @@
 import { describe, test, expect } from "bun:test";
 import { ToPtable } from "../../../src/operations/output/toptable.ts";
+import { Record as RSRecord } from "../../../src/Record.ts";
+import { CollectorReceiver } from "../../../src/Operation.ts";
+import type { JsonObject } from "../../../src/types/json.ts";
 import { testOutput } from "./testHelper.ts";
+
+/**
+ * Helper for --records mode: returns the collected Record objects.
+ */
+function testRecordOutput(args: string[], input: string): RSRecord[] {
+  const collector = new CollectorReceiver();
+  const op = new ToPtable(collector);
+  op.init(args);
+
+  const lines = input.split("\n").filter((l) => l.trim() !== "");
+  for (const line of lines) {
+    op.acceptLine(line);
+  }
+  op.finish();
+
+  return collector.records;
+}
 
 describe("ToPtable", () => {
   const stream1 = `{"c":"0","a":"2","b":"2","d":"2","ct":2}
@@ -121,5 +141,220 @@ describe("ToPtable", () => {
       const allIdx = uidLine.indexOf("ALL");
       expect(rootIdx).toBeLessThan(allIdx);
     }
+  });
+
+  describe("record output mode (--records / --recs)", () => {
+    const simpleStream = `{"row":"A","col":"X","val":1}
+{"row":"A","col":"Y","val":2}
+{"row":"B","col":"X","val":3}
+{"row":"B","col":"Y","val":4}`;
+
+    test("--records outputs records instead of table", () => {
+      const records = testRecordOutput(
+        ["--x", "col", "--y", "row", "--v", "val", "--records"],
+        simpleStream,
+      );
+      expect(records.length).toBe(2);
+
+      // Each record should have row field and nested col structure
+      const recA = records.find((r) => r.get("row") === "A");
+      const recB = records.find((r) => r.get("row") === "B");
+      expect(recA).toBeDefined();
+      expect(recB).toBeDefined();
+
+      // X-axis values are nested under the x field name
+      const colA = recA!.get("col") as JsonObject;
+      expect(colA["X"]).toBe("1");
+      expect(colA["Y"]).toBe("2");
+
+      const colB = recB!.get("col") as JsonObject;
+      expect(colB["X"]).toBe("3");
+      expect(colB["Y"]).toBe("4");
+    });
+
+    test("--recs is an alias for --records", () => {
+      const records = testRecordOutput(
+        ["--x", "col", "--y", "row", "--v", "val", "--recs"],
+        simpleStream,
+      );
+      expect(records.length).toBe(2);
+
+      const recA = records.find((r) => r.get("row") === "A");
+      expect(recA).toBeDefined();
+      const colA = recA!.get("col") as JsonObject;
+      expect(colA["X"]).toBe("1");
+    });
+
+    test("--records with multiple x fields creates nested structure", () => {
+      const input = `{"x1":"a","x2":"p","y1":"R","val":10}
+{"x1":"a","x2":"q","y1":"R","val":20}
+{"x1":"b","x2":"p","y1":"R","val":30}`;
+
+      const records = testRecordOutput(
+        ["--x", "x1,x2", "--y", "y1", "--v", "val", "--records"],
+        input,
+      );
+      expect(records.length).toBe(1);
+
+      const rec = records[0]!;
+      expect(rec.get("y1")).toBe("R");
+      // Nested: x1 -> { a -> { x2 -> { p -> "10", q -> "20" } }, b -> { x2 -> { p -> "30" } } }
+      const x1 = rec.get("x1") as JsonObject;
+      expect(x1).toBeDefined();
+      expect(typeof x1).toBe("object");
+    });
+  });
+
+  describe("KeyGroups syntax", () => {
+    // Records with fields a, b, c, ct - use KeyGroups to select fields by pattern
+    const kgStream = `{"a":"0","b":"1","c":"2","ct":5}
+{"a":"1","b":"0","c":"1","ct":3}
+{"a":"0","b":"0","c":"0","ct":7}`;
+
+    test("!pattern! matches fields by regex", () => {
+      // !b! matches field "b"
+      const actual = testOutput(ToPtable, ["--x", "!b!", "--y", "a", "--v", "ct"], kgStream);
+      expect(actual).toContain("|");
+      // b values should appear as columns
+      expect(actual).toContain("1");
+      expect(actual).toContain("0");
+      // ct values should appear
+      expect(actual).toContain("5");
+      expect(actual).toContain("3");
+      expect(actual).toContain("7");
+    });
+
+    test("!regex!sort matches and sorts fields", () => {
+      // !^(a|c)$!sort matches fields a and c, sorted alphabetically
+      const actual = testOutput(ToPtable, ["--y", "!^(a|c)$!sort", "--v", "ct"], kgStream);
+      expect(actual).toContain("|");
+      // Both a and c should appear as y-axis
+      expect(actual).toContain("a");
+      expect(actual).toContain("c");
+    });
+
+    test("KeyGroups with FIELD on x-axis", () => {
+      const input = `{"a":"0","b":"1","avg_d":2.5,"ct":10}
+{"a":"1","b":"0","avg_d":1.0,"ct":20}`;
+
+      // Use !^(avg_d|ct)$!sort for value fields via KeyGroups
+      const actual = testOutput(
+        ToPtable,
+        ["--x", "b,FIELD", "--y", "a", "--v", "!^(avg_d|ct)$!sort"],
+        input,
+      );
+      expect(actual).toContain("FIELD");
+      expect(actual).toContain("avg_d");
+      expect(actual).toContain("ct");
+    });
+  });
+
+  describe("value field ordering", () => {
+    test("--v field1,field2 preserves specified order", () => {
+      const input = `{"a":"0","b":"1","ct":10,"avg_d":2.5}
+{"a":"1","b":"0","ct":20,"avg_d":1.0}`;
+
+      // Request ct,avg_d order — ct should come first
+      const actual1 = testOutput(
+        ToPtable,
+        ["--x", "b,FIELD", "--y", "a", "--v", "ct,avg_d"],
+        input,
+      );
+      // Find the line with both ct and avg_d — ct should appear before avg_d
+      const lines1 = actual1.split("\n");
+      const fieldLine1 = lines1.find((l) => l.includes("ct") && l.includes("avg_d"));
+      expect(fieldLine1).toBeDefined();
+      expect(fieldLine1!.indexOf("ct")).toBeLessThan(fieldLine1!.indexOf("avg_d"));
+
+      // Now reverse: avg_d,ct order — avg_d should come first
+      const actual2 = testOutput(
+        ToPtable,
+        ["--x", "b,FIELD", "--y", "a", "--v", "avg_d,ct"],
+        input,
+      );
+      const lines2 = actual2.split("\n");
+      const fieldLine2 = lines2.find((l) => l.includes("ct") && l.includes("avg_d"));
+      expect(fieldLine2).toBeDefined();
+      expect(fieldLine2!.indexOf("avg_d")).toBeLessThan(fieldLine2!.indexOf("ct"));
+    });
+  });
+
+  describe("multiple pins", () => {
+    test("multiple --pin options filter on all pinned fields", () => {
+      // Pin both a=0 and c=2 — only records where a=0 AND c=2 pass
+      const actual = testOutput(
+        ToPtable,
+        ["--x", "b", "--y", "d", "--pin", "a=0", "--pin", "c=2"],
+        stream1,
+      );
+      expect(actual).toContain("|");
+      // From stream1, records with a=0 and c=2:
+      // {"c":"2","a":"0","b":"0","d":"1","ct":1}
+      // {"c":"2","a":"0","b":"0","d":"0","ct":22}
+      // {"c":"2","a":"0","b":"0","d":"2","ct":6}
+      // {"c":"2","a":"0","b":"2","d":"2","ct":27}
+      // {"c":"2","a":"0","b":"2","d":"1","ct":4}
+      // {"c":"2","a":"0","b":"2","d":"0","ct":2}
+      expect(actual).toContain("22");
+      expect(actual).toContain("27");
+      expect(actual).toContain("6");
+      // Values from records NOT matching both pins should be absent
+      // e.g. ct=8 is from {a:2, c:1} — should not be present
+      // (ct=8 also appears in {a:1,c:0,d:2} and {a:1,c:1,d:1} — all excluded)
+    });
+
+    test("single --pin with comma-separated pairs", () => {
+      // --pin a=0,c=2 should also work as multiple pins
+      const actual = testOutput(
+        ToPtable,
+        ["--x", "b", "--y", "d", "--pin", "a=0,c=2"],
+        stream1,
+      );
+      expect(actual).toContain("22");
+      expect(actual).toContain("27");
+    });
+  });
+
+  describe("FIELD pin", () => {
+    test("--pin FIELD=specific_field limits value fields displayed", () => {
+      const input = `{"a":"0","b":"1","avg_d":2.5,"ct":10}
+{"a":"1","b":"0","avg_d":1.0,"ct":20}`;
+
+      // With FIELD pin, only show the pinned value field
+      const actual = testOutput(
+        ToPtable,
+        ["--x", "b,FIELD", "--y", "a", "--pin", "FIELD=ct"],
+        input,
+      );
+      // ct should appear but avg_d should NOT appear as a FIELD value
+      expect(actual).toContain("ct");
+      expect(actual).not.toContain("avg_d");
+      // ct values should be present
+      expect(actual).toContain("10");
+      expect(actual).toContain("20");
+    });
+
+    test("--pin FIELD works with --records mode", () => {
+      const input = `{"a":"0","b":"1","avg_d":2.5,"ct":10}
+{"a":"1","b":"0","avg_d":1.0,"ct":20}`;
+
+      const records = testRecordOutput(
+        ["--x", "b,FIELD", "--y", "a", "--pin", "FIELD=avg_d", "--records"],
+        input,
+      );
+      expect(records.length).toBe(2);
+
+      // Only avg_d should be present, not ct
+      const rec0 = records.find((r) => r.get("a") === "0");
+      expect(rec0).toBeDefined();
+      // Structure: b -> { "1": { FIELD: { avg_d: "2.5" } }, "0": { FIELD: { avg_d: "" } } }
+      const data = rec0!.toJSON() as JsonObject;
+      const bObj = data["b"] as JsonObject;
+      const b1 = bObj["1"] as JsonObject;
+      const fieldObj = b1["FIELD"] as JsonObject;
+      expect(fieldObj["avg_d"]).toBe("2.5");
+      // ct should not be present since we pinned FIELD=avg_d
+      expect(fieldObj["ct"]).toBeUndefined();
+    });
   });
 });

--- a/tests/operations/transform/chain.test.ts
+++ b/tests/operations/transform/chain.test.ts
@@ -79,3 +79,209 @@ describe("ChainOperation", () => {
     expect(collector.records.length).toBe(0);
   });
 });
+
+describe("ChainOperation with shell commands", () => {
+  test("shell command pass-through with cat", async () => {
+    const collector = new CollectorReceiver();
+    const chain = new ChainOperation(collector);
+    chain.init(["cat"]);
+
+    chain.feedRecords([
+      new Record({ x: 1 }),
+      new Record({ x: 2 }),
+    ]);
+    await chain.finish();
+
+    expect(collector.records.length).toBe(2);
+    expect(collector.records[0]!.get("x")).toBe(1);
+    expect(collector.records[1]!.get("x")).toBe(2);
+  });
+
+  test("shell command with grep filter", async () => {
+    const collector = new CollectorReceiver();
+    const chain = new ChainOperation(collector);
+    // Use /usr/bin/grep to ensure shell command, not recs grep operation
+    chain.init(["/usr/bin/grep", "foo"]);
+
+    chain.feedRecords([
+      new Record({ name: "foo" }),
+      new Record({ name: "bar" }),
+      new Record({ name: "foobar" }),
+    ]);
+    await chain.finish();
+
+    expect(collector.records.length).toBe(2);
+    expect(collector.records[0]!.get("name")).toBe("foo");
+    expect(collector.records[1]!.get("name")).toBe("foobar");
+  });
+
+  test("recs op then shell command", async () => {
+    const collector = new CollectorReceiver();
+    const chain = new ChainOperation(collector);
+    chain.init(["double", "x", "|", "cat"]);
+
+    chain.feedRecords([
+      new Record({ x: 5 }),
+      new Record({ x: 10 }),
+    ]);
+    await chain.finish();
+
+    expect(collector.records.length).toBe(2);
+    expect(collector.records[0]!.get("x")).toBe(10);
+    expect(collector.records[1]!.get("x")).toBe(20);
+  });
+
+  test("shell command then recs op", async () => {
+    const collector = new CollectorReceiver();
+    const chain = new ChainOperation(collector);
+    chain.init(["cat", "|", "double", "x"]);
+
+    chain.feedRecords([
+      new Record({ x: 3 }),
+    ]);
+    await chain.finish();
+
+    expect(collector.records.length).toBe(1);
+    expect(collector.records[0]!.get("x")).toBe(6);
+  });
+
+  test("mixed recs and shell commands", async () => {
+    const collector = new CollectorReceiver();
+    const chain = new ChainOperation(collector);
+    chain.init(["double", "x", "|", "cat", "|", "add-field"]);
+
+    chain.feedRecords([
+      new Record({ x: 5 }),
+    ]);
+    await chain.finish();
+
+    expect(collector.records.length).toBe(1);
+    expect(collector.records[0]!.get("x")).toBe(10);
+    expect(collector.records[0]!.get("added")).toBe(true);
+  });
+
+  test("shell command with no input produces no output", async () => {
+    const collector = new CollectorReceiver();
+    const chain = new ChainOperation(collector);
+    chain.init(["cat"]);
+
+    // Don't feed any records
+    await chain.finish();
+
+    expect(collector.records.length).toBe(0);
+  });
+
+  test("multiple records through shell command", async () => {
+    const collector = new CollectorReceiver();
+    const chain = new ChainOperation(collector);
+    chain.init(["cat"]);
+
+    const records = [];
+    for (let i = 0; i < 100; i++) {
+      records.push(new Record({ i }));
+    }
+    chain.feedRecords(records);
+    await chain.finish();
+
+    expect(collector.records.length).toBe(100);
+    for (let i = 0; i < 100; i++) {
+      expect(collector.records[i]!.get("i")).toBe(i);
+    }
+  });
+
+  test("early process exit (head -1) is handled gracefully", async () => {
+    const collector = new CollectorReceiver();
+    const chain = new ChainOperation(collector);
+    chain.init(["head", "-1"]);
+
+    // Feed multiple records; head -1 only consumes the first line.
+    // Due to pipe buffering, writes may succeed even after head exits,
+    // so we just verify no crash and correct output.
+    chain.feedRecords([
+      new Record({ x: 1 }),
+      new Record({ x: 2 }),
+      new Record({ x: 3 }),
+    ]);
+
+    await chain.finish();
+
+    // head -1 should produce exactly one record
+    expect(collector.records.length).toBe(1);
+    expect(collector.records[0]!.get("x")).toBe(1);
+  });
+
+  test("shell command failure does not crash", async () => {
+    const collector = new CollectorReceiver();
+    const chain = new ChainOperation(collector);
+    chain.init(["bash", "-c", "exit 1"]);
+
+    chain.feedRecords([new Record({ x: 1 })]);
+    await chain.finish();
+
+    // The command exits with non-zero, but chain should not throw
+    // No output expected since the command doesn't produce any
+    expect(collector.records.length).toBe(0);
+  });
+
+  test("stderr output is forwarded", async () => {
+    const collector = new CollectorReceiver();
+    const chain = new ChainOperation(collector);
+    chain.init(["bash", "-c", "echo stderr-msg >&2 && cat"]);
+
+    // Capture stderr
+    const stderrChunks: string[] = [];
+    const origWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = (chunk: Uint8Array | string): boolean => {
+      stderrChunks.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString());
+      return true;
+    };
+
+    try {
+      chain.feedRecords([new Record({ x: 1 })]);
+      await chain.finish();
+    } finally {
+      process.stderr.write = origWrite;
+    }
+
+    // Verify stderr was forwarded
+    const allStderr = stderrChunks.join("");
+    expect(allStderr).toContain("stderr-msg");
+
+    // And stdout still works (cat passes through the record)
+    expect(collector.records.length).toBe(1);
+    expect(collector.records[0]!.get("x")).toBe(1);
+  });
+
+  test("malformed JSON in shell output is pushed as a line", async () => {
+    const collector = new CollectorReceiver();
+    const chain = new ChainOperation(collector);
+    // Echo non-JSON text instead of passing through records
+    chain.init(["bash", "-c", "echo 'not json'; echo 'also not json'"]);
+
+    chain.feedRecords([new Record({ x: 1 })]);
+    await chain.finish();
+
+    // Non-JSON lines should be pushed as lines, not crash
+    expect(collector.lines.length).toBe(2);
+    expect(collector.lines[0]).toBe("not json");
+    expect(collector.lines[1]).toBe("also not json");
+  });
+
+  test("incremental record arrival via acceptRecord", async () => {
+    const collector = new CollectorReceiver();
+    const chain = new ChainOperation(collector);
+    chain.init(["cat"]);
+
+    // Feed records one at a time instead of batch
+    chain.acceptRecord(new Record({ i: 0 }));
+    chain.acceptRecord(new Record({ i: 1 }));
+    chain.acceptRecord(new Record({ i: 2 }));
+
+    await chain.finish();
+
+    expect(collector.records.length).toBe(3);
+    expect(collector.records[0]!.get("i")).toBe(0);
+    expect(collector.records[1]!.get("i")).toBe(1);
+    expect(collector.records[2]!.get("i")).toBe(2);
+  });
+});

--- a/tests/operations/transform/collate.test.ts
+++ b/tests/operations/transform/collate.test.ts
@@ -2,71 +2,11 @@ import { describe, test, expect } from "bun:test";
 import { Record } from "../../../src/Record.ts";
 import { CollectorReceiver } from "../../../src/Operation.ts";
 import { CollateOperation } from "../../../src/operations/transform/collate.ts";
-import { aggregatorRegistry } from "../../../src/Aggregator.ts";
-import type { Aggregator } from "../../../src/Aggregator.ts";
-import type { JsonValue } from "../../../src/types/json.ts";
 
-// Register basic aggregators for testing
-function registerTestAggregators(): void {
-  if (aggregatorRegistry.has("count")) return;
-
-  aggregatorRegistry.register("count", {
-    create: () => ({
-      initial: () => 0,
-      combine: (state: unknown) => (state as number) + 1,
-      squish: (state: unknown) => state as JsonValue,
-    }) as Aggregator,
-    argCounts: [0],
-    shortUsage: "Count records",
-    longUsage: "Counts the number of records",
-    aliases: ["ct"],
-  });
-
-  aggregatorRegistry.register("sum", {
-    create: (field: string) => ({
-      initial: () => 0,
-      combine: (state: unknown, record: Record) => {
-        const val = record.get(field);
-        return (state as number) + (typeof val === "number" ? val : Number(val));
-      },
-      squish: (state: unknown) => state as JsonValue,
-    }) as Aggregator,
-    argCounts: [1],
-    shortUsage: "Sum a field",
-    longUsage: "Sums the values of the specified field",
-  });
-
-  aggregatorRegistry.register("max", {
-    create: (field: string) => ({
-      initial: () => -Infinity,
-      combine: (state: unknown, record: Record) => {
-        const val = Number(record.get(field));
-        return Math.max(state as number, val);
-      },
-      squish: (state: unknown) => state as JsonValue,
-    }) as Aggregator,
-    argCounts: [1],
-    shortUsage: "Max of a field",
-    longUsage: "Finds the maximum value of the specified field",
-  });
-
-  aggregatorRegistry.register("min", {
-    create: (field: string) => ({
-      initial: () => Infinity,
-      combine: (state: unknown, record: Record) => {
-        const val = Number(record.get(field));
-        return Math.min(state as number, val);
-      },
-      squish: (state: unknown) => state as JsonValue,
-    }) as Aggregator,
-    argCounts: [1],
-    shortUsage: "Min of a field",
-    longUsage: "Finds the minimum value of the specified field",
-  });
-}
+// Import the real aggregator registry so all aggregators are available
+import "../../../src/aggregators/registry.ts";
 
 function makeOp(args: string[]): { op: CollateOperation; collector: CollectorReceiver } {
-  registerTestAggregators();
   const collector = new CollectorReceiver();
   const op = new CollateOperation(collector);
   op.init(args);
@@ -185,5 +125,392 @@ describe("CollateOperation", () => {
     expect(collector.records[0]!.get("count")).toBe(1);
     expect(collector.records[1]!.get("count")).toBe(2);
     expect(collector.records[2]!.get("count")).toBe(3);
+  });
+});
+
+describe("Cube mode", () => {
+  test("single key produces value and ALL groups", () => {
+    const { op, collector } = makeOp(["--key", "color", "--cube", "-a", "count"]);
+    feedRecords(op, [
+      new Record({ color: "red", x: 1 }),
+      new Record({ color: "blue", x: 2 }),
+      new Record({ color: "red", x: 3 }),
+    ]);
+
+    // 2 unique values + ALL = 3 groups
+    expect(collector.records.length).toBe(3);
+
+    const byColor = new Map<string, number>();
+    for (const r of collector.records) {
+      byColor.set(r.get("color") as string, r.get("count") as number);
+    }
+    expect(byColor.get("red")).toBe(2);
+    expect(byColor.get("blue")).toBe(1);
+    expect(byColor.get("ALL")).toBe(3);
+  });
+
+  test("two keys produce all 2^2 combinations", () => {
+    const { op, collector } = makeOp(["--key", "a,b", "--cube", "-a", "count"]);
+    feedRecords(op, [
+      new Record({ a: "x", b: "y" }),
+      new Record({ a: "x", b: "z" }),
+    ]);
+
+    // Groups: (x,y), (ALL,y), (x,ALL), (ALL,ALL), (x,z), (ALL,z)
+    expect(collector.records.length).toBe(6);
+
+    const byKey = new Map<string, number>();
+    for (const r of collector.records) {
+      const key = `${r.get("a")},${r.get("b")}`;
+      byKey.set(key, r.get("count") as number);
+    }
+    expect(byKey.get("x,y")).toBe(1);
+    expect(byKey.get("x,z")).toBe(1);
+    expect(byKey.get("ALL,y")).toBe(1);
+    expect(byKey.get("ALL,z")).toBe(1);
+    expect(byKey.get("x,ALL")).toBe(2);
+    expect(byKey.get("ALL,ALL")).toBe(2);
+  });
+
+  test("cube with sum aggregation", () => {
+    const { op, collector } = makeOp([
+      "--key", "region,product", "--cube",
+      "-a", "revenue=sum,amount",
+    ]);
+    feedRecords(op, [
+      new Record({ region: "east", product: "A", amount: 100 }),
+      new Record({ region: "east", product: "B", amount: 200 }),
+      new Record({ region: "west", product: "A", amount: 300 }),
+    ]);
+
+    const byKey = new Map<string, number>();
+    for (const r of collector.records) {
+      const key = `${r.get("region")},${r.get("product")}`;
+      byKey.set(key, r.get("revenue") as number);
+    }
+
+    // Specific combos
+    expect(byKey.get("east,A")).toBe(100);
+    expect(byKey.get("east,B")).toBe(200);
+    expect(byKey.get("west,A")).toBe(300);
+
+    // Rollups
+    expect(byKey.get("east,ALL")).toBe(300);
+    expect(byKey.get("west,ALL")).toBe(300);
+    expect(byKey.get("ALL,A")).toBe(400);
+    expect(byKey.get("ALL,B")).toBe(200);
+    expect(byKey.get("ALL,ALL")).toBe(600);
+  });
+});
+
+describe("Domain language", () => {
+  test("--dlaggregator with sum", () => {
+    const { op, collector } = makeOp(["--dlaggregator", 'my_sum=sum("x")']);
+    feedRecords(op, [
+      new Record({ x: 10 }),
+      new Record({ x: 20 }),
+      new Record({ x: 30 }),
+    ]);
+
+    expect(collector.records.length).toBe(1);
+    expect(collector.records[0]!.get("my_sum")).toBe(60);
+  });
+
+  test("--dlaggregator with count", () => {
+    const { op, collector } = makeOp(["--dlaggregator", "n=count()"]);
+    feedRecords(op, [
+      new Record({ x: 1 }),
+      new Record({ x: 2 }),
+    ]);
+
+    expect(collector.records.length).toBe(1);
+    expect(collector.records[0]!.get("n")).toBe(2);
+  });
+
+  test("--dlaggregator combined with regular aggregator", () => {
+    const { op, collector } = makeOp([
+      "-a", "count",
+      "--dlaggregator", 'total=sum("x")',
+    ]);
+    feedRecords(op, [
+      new Record({ x: 5 }),
+      new Record({ x: 15 }),
+    ]);
+
+    expect(collector.records[0]!.get("count")).toBe(2);
+    expect(collector.records[0]!.get("total")).toBe(20);
+  });
+
+  test("--dlaggregator with key grouping", () => {
+    const { op, collector } = makeOp([
+      "--key", "group",
+      "--dlaggregator", 'total=sum("val")',
+    ]);
+    feedRecords(op, [
+      new Record({ group: "A", val: 10 }),
+      new Record({ group: "B", val: 20 }),
+      new Record({ group: "A", val: 30 }),
+    ]);
+
+    const byGroup = new Map<string, number>();
+    for (const r of collector.records) {
+      byGroup.set(r.get("group") as string, r.get("total") as number);
+    }
+    expect(byGroup.get("A")).toBe(40);
+    expect(byGroup.get("B")).toBe(20);
+  });
+
+  test("--dlaggregator errors on missing = separator", () => {
+    expect(() => {
+      makeOp(["--dlaggregator", "bad_spec_no_equals"]);
+    }).toThrow(/missing '='/);
+  });
+});
+
+describe("Null and missing value handling", () => {
+  test("null key values are grouped together", () => {
+    const { op, collector } = makeOp(["--key", "group", "-a", "count"]);
+    feedRecords(op, [
+      new Record({ group: "A", x: 1 }),
+      new Record({ group: null, x: 2 }),
+      new Record({ x: 3 }), // missing group key
+    ]);
+
+    expect(collector.records.length).toBe(2);
+
+    const byGroup = new Map<string, number>();
+    for (const r of collector.records) {
+      const key = String(r.get("group"));
+      byGroup.set(key, r.get("count") as number);
+    }
+    expect(byGroup.get("A")).toBe(1);
+    // null and undefined/missing are grouped together
+    expect(byGroup.get("null")).toBe(2);
+  });
+
+  test("sum skips null/undefined values in field", () => {
+    const { op, collector } = makeOp(["-a", "total=sum,x"]);
+    feedRecords(op, [
+      new Record({ x: 10 }),
+      new Record({ x: null }),
+      new Record({ y: 5 }), // x is missing
+      new Record({ x: 20 }),
+    ]);
+
+    expect(collector.records.length).toBe(1);
+    // sum of 10 + NaN(null) + NaN(undefined) + 20 — depends on implementation
+    // The hand-registered sum in old test doesn't skip nulls, but real Sum does
+    const total = collector.records[0]!.get("total") as number;
+    expect(total).toBe(30);
+  });
+
+  test("count counts all records including those with null keys", () => {
+    const { op, collector } = makeOp([
+      "--key", "category",
+      "-a", "count",
+    ]);
+    feedRecords(op, [
+      new Record({ category: "A" }),
+      new Record({ category: "A" }),
+      new Record({ category: null }),
+      new Record({}), // missing category
+    ]);
+
+    const byCategory = new Map<string, number>();
+    for (const r of collector.records) {
+      const key = String(r.get("category"));
+      byCategory.set(key, r.get("count") as number);
+    }
+    expect(byCategory.get("A")).toBe(2);
+    expect(byCategory.get("null")).toBe(2);
+  });
+
+  test("avg handles null values gracefully", () => {
+    const { op, collector } = makeOp(["-a", "avg,x"]);
+    feedRecords(op, [
+      new Record({ x: 10 }),
+      new Record({ x: null }),
+      new Record({ x: 30 }),
+    ]);
+
+    expect(collector.records.length).toBe(1);
+    // avg should skip nulls: (10 + 30) / 2 = 20
+    expect(collector.records[0]!.get("avg_x")).toBe(20);
+  });
+});
+
+describe("--no-bucket mode", () => {
+  test("outputs one record per input record with aggregated values", () => {
+    const { op, collector } = makeOp([
+      "--key", "area",
+      "--no-bucket",
+      "-a", "count",
+    ]);
+    feedRecords(op, [
+      new Record({ area: "A", x: 1 }),
+      new Record({ area: "B", x: 2 }),
+      new Record({ area: "A", x: 3 }),
+    ]);
+
+    // One output per input record
+    expect(collector.records.length).toBe(3);
+
+    // Each record retains its original fields plus the aggregated values
+    const aRecords = collector.records.filter(r => r.get("area") === "A");
+    const bRecords = collector.records.filter(r => r.get("area") === "B");
+    expect(aRecords.length).toBe(2);
+    expect(bRecords.length).toBe(1);
+
+    // All records in same group get the same aggregated value
+    for (const r of aRecords) {
+      expect(r.get("count")).toBe(2);
+    }
+    expect(bRecords[0]!.get("count")).toBe(1);
+  });
+
+  test("preserves original record fields", () => {
+    const { op, collector } = makeOp([
+      "--key", "area",
+      "--no-bucket",
+      "-a", "total=sum,x",
+    ]);
+    feedRecords(op, [
+      new Record({ area: "A", x: 10, extra: "hello" }),
+      new Record({ area: "A", x: 20, extra: "world" }),
+    ]);
+
+    expect(collector.records.length).toBe(2);
+    expect(collector.records[0]!.get("extra")).toBe("hello");
+    expect(collector.records[1]!.get("extra")).toBe("world");
+    expect(collector.records[0]!.get("total")).toBe(30);
+    expect(collector.records[1]!.get("total")).toBe(30);
+  });
+
+  test("no-bucket without key: all records get same aggregation", () => {
+    const { op, collector } = makeOp([
+      "--no-bucket",
+      "-a", "count",
+    ]);
+    feedRecords(op, [
+      new Record({ x: 1 }),
+      new Record({ x: 2 }),
+      new Record({ x: 3 }),
+    ]);
+
+    expect(collector.records.length).toBe(3);
+    for (const r of collector.records) {
+      expect(r.get("count")).toBe(3);
+    }
+  });
+});
+
+describe("--mr-agg (MapReduce aggregator)", () => {
+  test("basic map-reduce count", () => {
+    const { op, collector } = makeOp(["--mr-agg", "my_count", "1", "$a + $b", "$a"]);
+    feedRecords(op, [
+      new Record({ x: 1 }),
+      new Record({ x: 2 }),
+      new Record({ x: 3 }),
+    ]);
+
+    expect(collector.records.length).toBe(1);
+    expect(collector.records[0]!.get("my_count")).toBe(3);
+  });
+
+  test("map-reduce sum with field access", () => {
+    const { op, collector } = makeOp([
+      "--mr-agg", "total", "{{x}}", "$a + $b", "$a",
+    ]);
+    feedRecords(op, [
+      new Record({ x: 10 }),
+      new Record({ x: 20 }),
+      new Record({ x: 30 }),
+    ]);
+
+    expect(collector.records.length).toBe(1);
+    expect(collector.records[0]!.get("total")).toBe(60);
+  });
+
+  test("map-reduce with key grouping", () => {
+    const { op, collector } = makeOp([
+      "--key", "group",
+      "--mr-agg", "total", "{{val}}", "$a + $b", "$a",
+    ]);
+    feedRecords(op, [
+      new Record({ group: "A", val: 10 }),
+      new Record({ group: "B", val: 20 }),
+      new Record({ group: "A", val: 30 }),
+    ]);
+
+    const byGroup = new Map<string, number>();
+    for (const r of collector.records) {
+      byGroup.set(r.get("group") as string, r.get("total") as number);
+    }
+    expect(byGroup.get("A")).toBe(40);
+    expect(byGroup.get("B")).toBe(20);
+  });
+
+  test("map-reduce combined with regular aggregator", () => {
+    const { op, collector } = makeOp([
+      "-a", "count",
+      "--mr-agg", "total", "{{x}}", "$a + $b", "$a",
+    ]);
+    feedRecords(op, [
+      new Record({ x: 5 }),
+      new Record({ x: 15 }),
+    ]);
+
+    expect(collector.records[0]!.get("count")).toBe(2);
+    expect(collector.records[0]!.get("total")).toBe(20);
+  });
+});
+
+describe("--ii-agg (InjectInto aggregator)", () => {
+  test("basic inject-into sum", () => {
+    const { op, collector } = makeOp([
+      "--ii-agg", "total", "0", "$a + {{x}}", "$a",
+    ]);
+    feedRecords(op, [
+      new Record({ x: 10 }),
+      new Record({ x: 20 }),
+      new Record({ x: 30 }),
+    ]);
+
+    expect(collector.records.length).toBe(1);
+    expect(collector.records[0]!.get("total")).toBe(60);
+  });
+
+  test("inject-into with array accumulator", () => {
+    const { op, collector } = makeOp([
+      "--ii-agg", "result", "[0,0]", "[$a[0]+{{val}},$a[1]+1]", "$a[0]/$a[1]",
+    ]);
+    feedRecords(op, [
+      new Record({ val: 10 }),
+      new Record({ val: 20 }),
+      new Record({ val: 30 }),
+    ]);
+
+    expect(collector.records.length).toBe(1);
+    // Average: (10+20+30)/3 = 20
+    expect(collector.records[0]!.get("result")).toBe(20);
+  });
+
+  test("inject-into with key grouping", () => {
+    const { op, collector } = makeOp([
+      "--key", "group",
+      "--ii-agg", "total", "0", "$a + {{val}}", "$a",
+    ]);
+    feedRecords(op, [
+      new Record({ group: "A", val: 10 }),
+      new Record({ group: "B", val: 20 }),
+      new Record({ group: "A", val: 30 }),
+    ]);
+
+    const byGroup = new Map<string, number>();
+    for (const r of collector.records) {
+      byGroup.set(r.get("group") as string, r.get("total") as number);
+    }
+    expect(byGroup.get("A")).toBe(40);
+    expect(byGroup.get("B")).toBe(20);
   });
 });

--- a/tests/operations/transform/decollate.test.ts
+++ b/tests/operations/transform/decollate.test.ts
@@ -1,30 +1,9 @@
 import { describe, test, expect } from "bun:test";
 import { Record } from "../../../src/Record.ts";
-import { CollectorReceiver } from "../../../src/Operation.ts";
+import { CollectorReceiver, HelpExit } from "../../../src/Operation.ts";
 import { DecollateOperation } from "../../../src/operations/transform/decollate.ts";
-import { deaggregatorRegistry } from "../../../src/Deaggregator.ts";
-import type { Deaggregator } from "../../../src/Deaggregator.ts";
-
-function registerTestDeaggregators(): void {
-  if (deaggregatorRegistry.has("split")) return;
-
-  deaggregatorRegistry.register("split", {
-    create: (field: string, delim: string, outputField: string) => ({
-      deaggregate: (record: Record): Record[] => {
-        const val = record.get(field);
-        if (typeof val !== "string") return [new Record()];
-        const parts = val.split(delim);
-        return parts.map((part) => new Record({ [outputField]: part }));
-      },
-    }) as Deaggregator,
-    argCounts: [3],
-    shortUsage: "Split a field",
-    longUsage: "Splits a field by delimiter into separate records",
-  });
-}
 
 function makeOp(args: string[]): { op: DecollateOperation; collector: CollectorReceiver } {
-  registerTestDeaggregators();
   const collector = new CollectorReceiver();
   const op = new DecollateOperation(collector);
   op.init(args);
@@ -32,27 +11,252 @@ function makeOp(args: string[]): { op: DecollateOperation; collector: CollectorR
 }
 
 describe("DecollateOperation", () => {
-  test("applies deaggregator to split records", () => {
-    const { op, collector } = makeOp(["--deaggregator", "split,hosts, ,host"]);
+  describe("split deaggregator", () => {
+    test("applies deaggregator to split records", () => {
+      const { op, collector } = makeOp(["--deaggregator", "split,hosts, ,host"]);
 
-    op.acceptRecord(new Record({ hosts: "a b c", group: "g1" }));
-    op.finish();
+      op.acceptRecord(new Record({ hosts: "a b c", group: "g1" }));
+      op.finish();
 
-    expect(collector.records.length).toBe(3);
-    // Each record should have the original fields plus the deaggregated field
-    expect(collector.records[0]!.get("host")).toBe("a");
-    expect(collector.records[0]!.get("group")).toBe("g1");
-    expect(collector.records[1]!.get("host")).toBe("b");
-    expect(collector.records[2]!.get("host")).toBe("c");
+      expect(collector.records.length).toBe(3);
+      // Each record should have the original fields plus the deaggregated field
+      expect(collector.records[0]!.get("host")).toBe("a");
+      expect(collector.records[0]!.get("group")).toBe("g1");
+      expect(collector.records[1]!.get("host")).toBe("b");
+      expect(collector.records[2]!.get("host")).toBe("c");
+    });
+
+    test("multiple input records", () => {
+      const { op, collector } = makeOp(["--deaggregator", "split,items,-,item"]);
+
+      op.acceptRecord(new Record({ items: "x-y" }));
+      op.acceptRecord(new Record({ items: "a-b-c" }));
+      op.finish();
+
+      expect(collector.records.length).toBe(5);
+    });
   });
 
-  test("multiple input records", () => {
-    const { op, collector } = makeOp(["--deaggregator", "split,items,-,item"]);
+  describe("unhash deaggregator", () => {
+    test("splits hash into key-value records", () => {
+      const { op, collector } = makeOp(["--deaggregator", "unhash,data,key,value"]);
 
-    op.acceptRecord(new Record({ items: "x-y" }));
-    op.acceptRecord(new Record({ items: "a-b-c" }));
-    op.finish();
+      op.acceptRecord(new Record({ data: { a: 1, b: 2, c: 3 }, name: "test" }));
+      op.finish();
 
-    expect(collector.records.length).toBe(5);
+      expect(collector.records.length).toBe(3);
+      // Keys should be sorted
+      expect(collector.records[0]!.get("key")).toBe("a");
+      expect(collector.records[0]!.get("value")).toBe(1);
+      expect(collector.records[0]!.get("name")).toBe("test");
+      expect(collector.records[1]!.get("key")).toBe("b");
+      expect(collector.records[1]!.get("value")).toBe(2);
+      expect(collector.records[2]!.get("key")).toBe("c");
+      expect(collector.records[2]!.get("value")).toBe(3);
+    });
+
+    test("splits hash with key only (no value field)", () => {
+      const { op, collector } = makeOp(["--deaggregator", "unhash,data,key"]);
+
+      op.acceptRecord(new Record({ data: { x: 10, y: 20 }, group: "g1" }));
+      op.finish();
+
+      expect(collector.records.length).toBe(2);
+      expect(collector.records[0]!.get("key")).toBe("x");
+      expect(collector.records[0]!.get("group")).toBe("g1");
+      expect(collector.records[1]!.get("key")).toBe("y");
+      // value field should not be set
+      expect(collector.records[0]!.get("value")).toBeUndefined();
+    });
+
+    test("returns no records for non-object", () => {
+      const { op, collector } = makeOp(["--deaggregator", "unhash,data,key,value"]);
+
+      op.acceptRecord(new Record({ data: "not a hash", name: "test" }));
+      op.finish();
+
+      expect(collector.records.length).toBe(0);
+    });
+  });
+
+  describe("unarray deaggregator", () => {
+    test("splits array into individual records", () => {
+      const { op, collector } = makeOp(["--deaggregator", "unarray,items,item"]);
+
+      op.acceptRecord(new Record({ items: [1, 2, 3], name: "test" }));
+      op.finish();
+
+      expect(collector.records.length).toBe(3);
+      expect(collector.records[0]!.get("item")).toBe(1);
+      expect(collector.records[0]!.get("name")).toBe("test");
+      expect(collector.records[1]!.get("item")).toBe(2);
+      expect(collector.records[2]!.get("item")).toBe(3);
+    });
+
+    test("handles array of objects", () => {
+      const { op, collector } = makeOp(["--deaggregator", "unarray,items,item"]);
+
+      op.acceptRecord(new Record({ items: [{ a: 1 }, { b: 2 }], group: "g1" }));
+      op.finish();
+
+      expect(collector.records.length).toBe(2);
+      expect(collector.records[0]!.get("item")).toEqual({ a: 1 });
+      expect(collector.records[0]!.get("group")).toBe("g1");
+      expect(collector.records[1]!.get("item")).toEqual({ b: 2 });
+    });
+
+    test("returns no records for non-array", () => {
+      const { op, collector } = makeOp(["--deaggregator", "unarray,items,item"]);
+
+      op.acceptRecord(new Record({ items: "not an array", name: "test" }));
+      op.finish();
+
+      expect(collector.records.length).toBe(0);
+    });
+  });
+
+  describe("chained deaggregators", () => {
+    test("applies two deaggregators in sequence with colon separator", () => {
+      const { op, collector } = makeOp([
+        "--deaggregator", "split,hosts, ,host:split,host,.,part",
+      ]);
+
+      op.acceptRecord(new Record({ hosts: "a.b c.d", group: "g1" }));
+      op.finish();
+
+      // "a.b" splits to ["a", "b"], "c.d" splits to ["c", "d"]
+      expect(collector.records.length).toBe(4);
+      expect(collector.records[0]!.get("part")).toBe("a");
+      expect(collector.records[0]!.get("group")).toBe("g1");
+      expect(collector.records[1]!.get("part")).toBe("b");
+      expect(collector.records[2]!.get("part")).toBe("c");
+      expect(collector.records[3]!.get("part")).toBe("d");
+    });
+
+    test("applies multiple -d flags in sequence", () => {
+      const { op, collector } = makeOp([
+        "-d", "split,hosts, ,host",
+        "-d", "split,host,.,part",
+      ]);
+
+      op.acceptRecord(new Record({ hosts: "a.b c.d" }));
+      op.finish();
+
+      expect(collector.records.length).toBe(4);
+      expect(collector.records[0]!.get("part")).toBe("a");
+      expect(collector.records[1]!.get("part")).toBe("b");
+      expect(collector.records[2]!.get("part")).toBe("c");
+      expect(collector.records[3]!.get("part")).toBe("d");
+    });
+
+    test("chains split then unhash", () => {
+      // First split a field containing JSON-like values, then unhash the result
+      const { op, collector } = makeOp([
+        "-d", "unhash,data,key,value",
+        "-d", "split,value,-,part",
+      ]);
+
+      op.acceptRecord(new Record({ data: { x: "a-b", y: "c-d" }, name: "test" }));
+      op.finish();
+
+      // unhash produces 2 records (x: "a-b", y: "c-d")
+      // then split on each value produces 2 records each: 4 total
+      expect(collector.records.length).toBe(4);
+      expect(collector.records[0]!.get("key")).toBe("x");
+      expect(collector.records[0]!.get("part")).toBe("a");
+      expect(collector.records[0]!.get("name")).toBe("test");
+      expect(collector.records[1]!.get("key")).toBe("x");
+      expect(collector.records[1]!.get("part")).toBe("b");
+      expect(collector.records[2]!.get("key")).toBe("y");
+      expect(collector.records[2]!.get("part")).toBe("c");
+      expect(collector.records[3]!.get("key")).toBe("y");
+      expect(collector.records[3]!.get("part")).toBe("d");
+    });
+
+    test("chains unarray then split", () => {
+      const { op, collector } = makeOp([
+        "-d", "unarray,items,item",
+        "-d", "split,item,-,part",
+      ]);
+
+      op.acceptRecord(new Record({ items: ["a-b", "c-d-e"], name: "test" }));
+      op.finish();
+
+      // unarray produces 2 records, then split on each
+      // "a-b" -> ["a", "b"], "c-d-e" -> ["c", "d", "e"]
+      expect(collector.records.length).toBe(5);
+      expect(collector.records[0]!.get("part")).toBe("a");
+      expect(collector.records[0]!.get("name")).toBe("test");
+      expect(collector.records[1]!.get("part")).toBe("b");
+      expect(collector.records[2]!.get("part")).toBe("c");
+      expect(collector.records[3]!.get("part")).toBe("d");
+      expect(collector.records[4]!.get("part")).toBe("e");
+    });
+  });
+
+  describe("--show-deaggregator", () => {
+    test("shows deaggregator usage", () => {
+      const collector = new CollectorReceiver();
+      const op = new DecollateOperation(collector);
+
+      expect(() => op.init(["--show-deaggregator", "split"])).toThrow(HelpExit);
+      try {
+        op.init(["--show-deaggregator", "split"]);
+      } catch (e) {
+        expect((e as HelpExit).message).toContain("split");
+      }
+    });
+
+    test("shows error for unknown deaggregator", () => {
+      const collector = new CollectorReceiver();
+      const op = new DecollateOperation(collector);
+
+      expect(() => op.init(["--show-deaggregator", "nonexistent"])).toThrow(HelpExit);
+      try {
+        op.init(["--show-deaggregator", "nonexistent"]);
+      } catch (e) {
+        expect((e as HelpExit).message).toContain("Bad deaggregator");
+      }
+    });
+  });
+
+  describe("--list-deaggregators", () => {
+    test("lists available deaggregators", () => {
+      const collector = new CollectorReceiver();
+      const op = new DecollateOperation(collector);
+
+      expect(() => op.init(["--list-deaggregators"])).toThrow(HelpExit);
+      try {
+        op.init(["--list-deaggregators"]);
+      } catch (e) {
+        const msg = (e as HelpExit).message;
+        expect(msg).toContain("split");
+        expect(msg).toContain("unarray");
+        expect(msg).toContain("unhash");
+      }
+    });
+  });
+
+  describe("--dldeaggregator", () => {
+    test("works as alias for -d", () => {
+      const { op, collector } = makeOp(["--dldeaggregator", "split,hosts, ,host"]);
+
+      op.acceptRecord(new Record({ hosts: "a b c", group: "g1" }));
+      op.finish();
+
+      expect(collector.records.length).toBe(3);
+      expect(collector.records[0]!.get("host")).toBe("a");
+      expect(collector.records[0]!.get("group")).toBe("g1");
+    });
+
+    test("short flag -D works", () => {
+      const { op, collector } = makeOp(["-D", "unarray,items,item"]);
+
+      op.acceptRecord(new Record({ items: [1, 2, 3] }));
+      op.finish();
+
+      expect(collector.records.length).toBe(3);
+      expect(collector.records[0]!.get("item")).toBe(1);
+    });
   });
 });

--- a/tests/operations/transform/eval.test.ts
+++ b/tests/operations/transform/eval.test.ts
@@ -60,6 +60,18 @@ describe("EvalOperation", () => {
     expect(op.doesRecordOutput()).toBe(false);
   });
 
+  test("chomp removes trailing newline", () => {
+    const { op, collector } = makeOp(["--chomp", "return {{boo}}"]);
+    op.acceptRecord(new Record({ boo: "hello\n" }));
+    op.acceptRecord(new Record({ boo: "multi\n\n" }));
+    op.finish();
+
+    expect(collector.lines.length).toBe(2);
+    expect(collector.lines[0]).toBe("hello");
+    // chomp only removes the last newline, not all trailing newlines
+    expect(collector.lines[1]).toBe("multi\n");
+  });
+
   test("requires expression", () => {
     expect(() => {
       const collector = new LineCollector();

--- a/tests/operations/transform/generate.test.ts
+++ b/tests/operations/transform/generate.test.ts
@@ -62,4 +62,136 @@ describe("GenerateOperation", () => {
       makeOp([]);
     }).toThrow("generate requires an expression");
   });
+
+  describe("--shell mode", () => {
+    test("basic shell command execution", () => {
+      const { op, collector } = makeOp([
+        "--shell",
+        'echo \'{"x": 1}\'',
+      ]);
+
+      op.acceptRecord(new Record({ id: 1 }));
+      op.finish();
+
+      expect(collector.records.length).toBe(1);
+      expect(collector.records[0]!.get("x")).toBe(1);
+      // Chain link should be present
+      const chain = collector.records[0]!.get("_chain") as { id: number };
+      expect(chain.id).toBe(1);
+    });
+
+    test("shell command that outputs multiple JSON records", () => {
+      const { op, collector } = makeOp([
+        "--shell",
+        'printf \'{"a": 1}\\n{"a": 2}\\n{"a": 3}\\n\'',
+      ]);
+
+      op.acceptRecord(new Record({ id: 10 }));
+      op.finish();
+
+      expect(collector.records.length).toBe(3);
+      expect(collector.records[0]!.get("a")).toBe(1);
+      expect(collector.records[1]!.get("a")).toBe(2);
+      expect(collector.records[2]!.get("a")).toBe(3);
+      // All should chain back to the input record
+      for (const rec of collector.records) {
+        const chain = rec.get("_chain") as { id: number };
+        expect(chain.id).toBe(10);
+      }
+    });
+
+    test("shell command with template interpolation", () => {
+      const { op, collector } = makeOp([
+        "--shell",
+        'echo \'{"greeting": "hello {{name}}"}\'',
+      ]);
+
+      op.acceptRecord(new Record({ name: "world" }));
+      op.finish();
+
+      expect(collector.records.length).toBe(1);
+      expect(collector.records[0]!.get("greeting")).toBe("hello world");
+    });
+
+    test("shell command with passthrough", () => {
+      const { op, collector } = makeOp([
+        "--shell", "--passthrough",
+        'echo \'{"x": 1}\'',
+      ]);
+
+      op.acceptRecord(new Record({ id: 5 }));
+      op.finish();
+
+      expect(collector.records.length).toBe(2);
+      // First record is the passthrough
+      expect(collector.records[0]!.get("id")).toBe(5);
+      // Second is the generated one
+      expect(collector.records[1]!.get("x")).toBe(1);
+    });
+
+    test("error handling for failed shell commands", () => {
+      const stderrMessages: string[] = [];
+      const origWrite = process.stderr.write;
+      process.stderr.write = ((chunk: string | Uint8Array) => {
+        stderrMessages.push(String(chunk));
+        return true;
+      }) as typeof process.stderr.write;
+
+      try {
+        const { op, collector } = makeOp([
+          "--shell",
+          "exit 1",
+        ]);
+
+        op.acceptRecord(new Record({ id: 1 }));
+        op.finish();
+
+        // No records should be generated
+        expect(collector.records.length).toBe(0);
+        // Should have written an error to stderr
+        expect(stderrMessages.some(m => m.includes("exited with status 1"))).toBe(true);
+      } finally {
+        process.stderr.write = origWrite;
+      }
+    });
+
+    test("shell command with invalid JSON output writes error to stderr", () => {
+      const stderrMessages: string[] = [];
+      const origWrite = process.stderr.write;
+      process.stderr.write = ((chunk: string | Uint8Array) => {
+        stderrMessages.push(String(chunk));
+        return true;
+      }) as typeof process.stderr.write;
+
+      try {
+        const { op, collector } = makeOp([
+          "--shell",
+          "echo not-json",
+        ]);
+
+        op.acceptRecord(new Record({ id: 1 }));
+        op.finish();
+
+        expect(collector.records.length).toBe(0);
+        expect(stderrMessages.some(m => m.includes("failed to parse JSON"))).toBe(true);
+      } finally {
+        process.stderr.write = origWrite;
+      }
+    });
+
+    test("shell command per record with different interpolations", () => {
+      const { op, collector } = makeOp([
+        "--shell",
+        'echo \'{"val": {{count}}}\'',
+      ]);
+
+      op.acceptRecord(new Record({ count: 10 }));
+      op.acceptRecord(new Record({ count: 20 }));
+      op.finish();
+
+      expect(collector.records.length).toBe(2);
+      expect(collector.records[0]!.get("val")).toBe(10);
+      expect(collector.records[1]!.get("val")).toBe(20);
+    });
+  });
 });

--- a/tests/operations/transform/sort.test.ts
+++ b/tests/operations/transform/sort.test.ts
@@ -102,4 +102,56 @@ describe("SortOperation", () => {
 
     expect(collector.records.map((r) => r.get("order"))).toEqual([1, 2, 3]);
   });
+
+  test("* postfix sorts ALL to end with numeric sort", () => {
+    const { op, collector } = makeOp(["--key", "count=numeric*"]);
+    feedRecords(op, [
+      new Record({ count: "ALL" }),
+      new Record({ count: 10 }),
+      new Record({ count: 2 }),
+      new Record({ count: 100 }),
+    ]);
+
+    expect(collector.records.map((r) => r.get("count"))).toEqual([2, 10, 100, "ALL"]);
+  });
+
+  test("* postfix sorts ALL to end with lexical sort", () => {
+    const { op, collector } = makeOp(["--key", "name=lexical*"]);
+    feedRecords(op, [
+      new Record({ name: "ALL" }),
+      new Record({ name: "charlie" }),
+      new Record({ name: "alpha" }),
+      new Record({ name: "bravo" }),
+    ]);
+
+    expect(collector.records.map((r) => r.get("name"))).toEqual([
+      "alpha", "bravo", "charlie", "ALL",
+    ]);
+  });
+
+  test("* postfix with ALL values among regular values", () => {
+    const { op, collector } = makeOp(["--key", "group=lexical*"]);
+    feedRecords(op, [
+      new Record({ group: "B" }),
+      new Record({ group: "ALL" }),
+      new Record({ group: "A" }),
+      new Record({ group: "ALL" }),
+      new Record({ group: "C" }),
+    ]);
+
+    expect(collector.records.map((r) => r.get("group"))).toEqual([
+      "A", "B", "C", "ALL", "ALL",
+    ]);
+  });
+
+  test("* postfix still sorts regular values correctly", () => {
+    const { op, collector } = makeOp(["--key", "val=numeric*"]);
+    feedRecords(op, [
+      new Record({ val: 50 }),
+      new Record({ val: 10 }),
+      new Record({ val: 30 }),
+    ]);
+
+    expect(collector.records.map((r) => r.get("val"))).toEqual([10, 30, 50]);
+  });
 });

--- a/tests/operations/transform/xform.test.ts
+++ b/tests/operations/transform/xform.test.ts
@@ -18,98 +18,643 @@ function feedRecords(op: XformOperation, records: Record[]): void {
 }
 
 describe("XformOperation", () => {
-  test("modifies records in place", () => {
-    const { op, collector } = makeOp(["{{line}} = $line"]);
-    feedRecords(op, [
-      new Record({ a: 1 }),
-      new Record({ a: 2 }),
-    ]);
+  describe("basic transformation", () => {
+    test("modifies records in place", () => {
+      const { op, collector } = makeOp(["{{line}} = $line"]);
+      feedRecords(op, [
+        new Record({ a: 1 }),
+        new Record({ a: 2 }),
+      ]);
 
-    expect(collector.records.length).toBe(2);
-    expect(collector.records[0]!.get("line")).toBe(1);
-    expect(collector.records[1]!.get("line")).toBe(2);
+      expect(collector.records.length).toBe(2);
+      expect(collector.records[0]!.get("line")).toBe(1);
+      expect(collector.records[1]!.get("line")).toBe(2);
+    });
+
+    test("can add new fields", () => {
+      const { op, collector } = makeOp(["{{sum}} = {{x}} + {{y}}"]);
+      feedRecords(op, [
+        new Record({ x: 3, y: 4 }),
+      ]);
+
+      expect(collector.records[0]!.get("sum")).toBe(7);
+    });
+
+    test("returns array to split records", () => {
+      const { op, collector } = makeOp(["return [{a: 1}, {a: 2}]"]);
+      feedRecords(op, [
+        new Record({ x: 1 }),
+      ]);
+
+      expect(collector.records.length).toBe(2);
+      expect(collector.records[0]!.get("a")).toBe(1);
+      expect(collector.records[1]!.get("a")).toBe(2);
+    });
+
+    test("requires expression", () => {
+      expect(() => {
+        makeOp([]);
+      }).toThrow("xform requires an expression");
+    });
+
+    test("passes through unmodified records", () => {
+      const { op, collector } = makeOp(["r"]);
+      feedRecords(op, [
+        new Record({ a: 1 }),
+      ]);
+
+      expect(collector.records.length).toBe(1);
+      expect(collector.records[0]!.get("a")).toBe(1);
+    });
+
+    test("handles multiple records", () => {
+      const { op, collector } = makeOp(["{{doubled}} = {{x}} * 2"]);
+      feedRecords(op, [
+        new Record({ x: 1 }),
+        new Record({ x: 2 }),
+        new Record({ x: 3 }),
+        new Record({ x: 4 }),
+        new Record({ x: 5 }),
+      ]);
+
+      expect(collector.records.length).toBe(5);
+      expect(collector.records[0]!.get("doubled")).toBe(2);
+      expect(collector.records[4]!.get("doubled")).toBe(10);
+    });
+
+    test("handles empty input", () => {
+      const { op, collector } = makeOp(["{{x}} = 1"]);
+      feedRecords(op, []);
+
+      expect(collector.records.length).toBe(0);
+    });
+
+    test("handles trailing comment in snippet", () => {
+      const { op, collector } = makeOp(["{{x}} = 1 // set x"]);
+      feedRecords(op, [
+        new Record({ a: 1 }),
+      ]);
+
+      expect(collector.records.length).toBe(1);
+      expect(collector.records[0]!.get("x")).toBe(1);
+    });
+
+    test("uses --expr/-e flag", () => {
+      const { op, collector } = makeOp(["-e", "{{x}} = {{a}} + 1"]);
+      feedRecords(op, [
+        new Record({ a: 5 }),
+      ]);
+
+      expect(collector.records[0]!.get("x")).toBe(6);
+    });
+
+    test("--expr takes precedence over positional arg", () => {
+      const { op, collector } = makeOp(["-e", "{{x}} = 42"]);
+      feedRecords(op, [
+        new Record({ a: 1 }),
+      ]);
+
+      expect(collector.records[0]!.get("x")).toBe(42);
+    });
+
+    test("array return with Record objects", () => {
+      const { op, collector } = makeOp(["return [r]"]);
+      feedRecords(op, [
+        new Record({ a: 1 }),
+      ]);
+
+      expect(collector.records.length).toBe(1);
+      expect(collector.records[0]!.get("a")).toBe(1);
+    });
+
+    test("returns empty array to suppress record", () => {
+      const { op, collector } = makeOp(["return []"]);
+      feedRecords(op, [
+        new Record({ a: 1 }),
+        new Record({ a: 2 }),
+      ]);
+
+      expect(collector.records.length).toBe(0);
+    });
+
+    test("conditional transformation", () => {
+      const { op, collector } = makeOp(["if ({{x}} > 2) { {{big}} = true }"]);
+      feedRecords(op, [
+        new Record({ x: 1 }),
+        new Record({ x: 3 }),
+        new Record({ x: 5 }),
+      ]);
+
+      expect(collector.records.length).toBe(3);
+      expect(collector.records[0]!.get("big")).toBeUndefined();
+      expect(collector.records[1]!.get("big")).toBe(true);
+      expect(collector.records[2]!.get("big")).toBe(true);
+    });
   });
 
-  test("can add new fields", () => {
-    const { op, collector } = makeOp(["{{sum}} = {{x}} + {{y}}"]);
-    feedRecords(op, [
-      new Record({ x: 3, y: 4 }),
-    ]);
+  describe("push_output", () => {
+    test("sends records directly to output", () => {
+      const { op, collector } = makeOp([
+        "push_output({x: r.get('a') * 10}); push_output({x: r.get('a') * 100})",
+      ]);
+      feedRecords(op, [
+        new Record({ a: 2 }),
+        new Record({ a: 3 }),
+      ]);
 
-    expect(collector.records[0]!.get("sum")).toBe(7);
+      expect(collector.records.length).toBe(4);
+      expect(collector.records[0]!.get("x")).toBe(20);
+      expect(collector.records[1]!.get("x")).toBe(200);
+      expect(collector.records[2]!.get("x")).toBe(30);
+      expect(collector.records[3]!.get("x")).toBe(300);
+    });
+
+    test("suppresses default record output", () => {
+      const { op, collector } = makeOp(["push_output({out: true})"]);
+      feedRecords(op, [
+        new Record({ a: 1 }),
+      ]);
+
+      // Only the pushed record should appear, not the original
+      expect(collector.records.length).toBe(1);
+      expect(collector.records[0]!.get("out")).toBe(true);
+    });
+
+    test("conditional suppression with push_output", () => {
+      const { op, collector } = makeOp([
+        "if ({{x}} > 2) { push_output({filtered: {{x}}}) }",
+      ]);
+      feedRecords(op, [
+        new Record({ x: 1 }),
+        new Record({ x: 3 }),
+        new Record({ x: 2 }),
+        new Record({ x: 5 }),
+      ]);
+
+      // Records with x <= 2 pass through normally; records with x > 2
+      // get replaced with the push_output record
+      expect(collector.records.length).toBe(4);
+      expect(collector.records[0]!.get("x")).toBe(1);
+      expect(collector.records[1]!.get("filtered")).toBe(3);
+      expect(collector.records[2]!.get("x")).toBe(2);
+      expect(collector.records[3]!.get("filtered")).toBe(5);
+    });
   });
 
-  test("returns array to split records", () => {
-    const { op, collector } = makeOp(["return [{a: 1}, {a: 2}]"]);
-    feedRecords(op, [
-      new Record({ x: 1 }),
-    ]);
+  describe("push_input", () => {
+    test("re-injects records into the input stream", () => {
+      // Use push_input to duplicate a record with a marker, but only once
+      const { op, collector } = makeOp([
+        "if (!r.get('dup')) { push_input({a: r.get('a'), dup: true}) }",
+      ]);
+      feedRecords(op, [
+        new Record({ a: 1 }),
+      ]);
 
-    expect(collector.records.length).toBe(2);
-    expect(collector.records[0]!.get("a")).toBe(1);
-    expect(collector.records[1]!.get("a")).toBe(2);
+      // The original is suppressed (push_input sets suppressR), then the
+      // duplicated record {a:1, dup:true} is re-processed and output normally
+      expect(collector.records.length).toBe(1);
+      expect(collector.records[0]!.get("a")).toBe(1);
+      expect(collector.records[0]!.get("dup")).toBe(true);
+    });
+
+    test("push_input with multiple records", () => {
+      const { op, collector } = makeOp([
+        "if (!r.get('seen')) { push_input({val: r.get('a'), seen: true}); push_input({val: r.get('a') * 2, seen: true}) }",
+      ]);
+      feedRecords(op, [
+        new Record({ a: 5 }),
+      ]);
+
+      // Original suppressed, two new records injected and processed
+      expect(collector.records.length).toBe(2);
+      expect(collector.records[0]!.get("val")).toBe(5);
+      expect(collector.records[1]!.get("val")).toBe(10);
+    });
   });
 
-  test("requires expression", () => {
-    expect(() => {
-      makeOp([]);
-    }).toThrow("xform requires an expression");
+  describe("context operations", () => {
+    test("before context with -B", () => {
+      const { op, collector } = makeOp([
+        "-B", "1",
+        "{{prev}} = B.length > 0 ? B[0].get('x') : null",
+      ]);
+      feedRecords(op, [
+        new Record({ x: 10 }),
+        new Record({ x: 20 }),
+        new Record({ x: 30 }),
+      ]);
+
+      expect(collector.records.length).toBe(3);
+      // First record has no before context
+      expect(collector.records[0]!.get("prev")).toBe(null);
+      // Second record sees first record in B
+      expect(collector.records[1]!.get("prev")).toBe(10);
+      // Third record sees second record in B
+      expect(collector.records[2]!.get("prev")).toBe(20);
+    });
+
+    test("before context with -B 2", () => {
+      const { op, collector } = makeOp([
+        "-B", "2",
+        "{{count}} = B.length",
+      ]);
+      feedRecords(op, [
+        new Record({ x: 1 }),
+        new Record({ x: 2 }),
+        new Record({ x: 3 }),
+        new Record({ x: 4 }),
+      ]);
+
+      expect(collector.records.length).toBe(4);
+      expect(collector.records[0]!.get("count")).toBe(0);
+      expect(collector.records[1]!.get("count")).toBe(1);
+      expect(collector.records[2]!.get("count")).toBe(2);
+      expect(collector.records[3]!.get("count")).toBe(2);
+    });
+
+    test("after context with -A", () => {
+      const { op, collector } = makeOp([
+        "-A", "1",
+        "{{next}} = A.length > 0 ? A[0].get('x') : null",
+      ]);
+      feedRecords(op, [
+        new Record({ x: 10 }),
+        new Record({ x: 20 }),
+        new Record({ x: 30 }),
+      ]);
+
+      expect(collector.records.length).toBe(3);
+      // First record sees second record in A
+      expect(collector.records[0]!.get("next")).toBe(20);
+      // Second record sees third record in A
+      expect(collector.records[1]!.get("next")).toBe(30);
+      // Third record has no after context
+      expect(collector.records[2]!.get("next")).toBe(null);
+    });
+
+    test("after context with -A 2", () => {
+      const { op, collector } = makeOp([
+        "-A", "2",
+        "{{count}} = A.length",
+      ]);
+      feedRecords(op, [
+        new Record({ x: 1 }),
+        new Record({ x: 2 }),
+        new Record({ x: 3 }),
+        new Record({ x: 4 }),
+      ]);
+
+      expect(collector.records.length).toBe(4);
+      expect(collector.records[0]!.get("count")).toBe(2);
+      expect(collector.records[1]!.get("count")).toBe(2);
+      expect(collector.records[2]!.get("count")).toBe(1);
+      expect(collector.records[3]!.get("count")).toBe(0);
+    });
+
+    test("combined context with -C", () => {
+      const { op, collector } = makeOp([
+        "-C", "1",
+        "{{before}} = B.length; {{after}} = A.length",
+      ]);
+      feedRecords(op, [
+        new Record({ x: 1 }),
+        new Record({ x: 2 }),
+        new Record({ x: 3 }),
+      ]);
+
+      expect(collector.records.length).toBe(3);
+      // First: no before, 1 after
+      expect(collector.records[0]!.get("before")).toBe(0);
+      expect(collector.records[0]!.get("after")).toBe(1);
+      // Middle: 1 before, 1 after
+      expect(collector.records[1]!.get("before")).toBe(1);
+      expect(collector.records[1]!.get("after")).toBe(1);
+      // Last: 1 before, no after
+      expect(collector.records[2]!.get("before")).toBe(1);
+      expect(collector.records[2]!.get("after")).toBe(0);
+    });
+
+    test("-C sets both before and after", () => {
+      const { op, collector } = makeOp([
+        "-C", "2",
+        "{{bLen}} = B.length; {{aLen}} = A.length",
+      ]);
+      feedRecords(op, [
+        new Record({ x: 1 }),
+        new Record({ x: 2 }),
+        new Record({ x: 3 }),
+        new Record({ x: 4 }),
+        new Record({ x: 5 }),
+      ]);
+
+      expect(collector.records.length).toBe(5);
+      expect(collector.records[0]!.get("bLen")).toBe(0);
+      expect(collector.records[0]!.get("aLen")).toBe(2);
+      expect(collector.records[2]!.get("bLen")).toBe(2);
+      expect(collector.records[2]!.get("aLen")).toBe(2);
+      expect(collector.records[4]!.get("bLen")).toBe(2);
+      expect(collector.records[4]!.get("aLen")).toBe(0);
+    });
+
+    test("context with single record", () => {
+      const { op, collector } = makeOp([
+        "-C", "1",
+        "{{before}} = B.length; {{after}} = A.length",
+      ]);
+      feedRecords(op, [
+        new Record({ x: 1 }),
+      ]);
+
+      expect(collector.records.length).toBe(1);
+      expect(collector.records[0]!.get("before")).toBe(0);
+      expect(collector.records[0]!.get("after")).toBe(0);
+    });
+
+    test("context with empty input", () => {
+      const { op, collector } = makeOp([
+        "-B", "2",
+        "{{count}} = B.length",
+      ]);
+      feedRecords(op, []);
+
+      expect(collector.records.length).toBe(0);
+    });
+
+    test("accessing before record values", () => {
+      const { op, collector } = makeOp([
+        "-B", "1",
+        "{{before_val}} = B.length > 0 ? B[0].get('x') : 'none'",
+      ]);
+      feedRecords(op, [
+        new Record({ x: "first" }),
+        new Record({ x: "second" }),
+        new Record({ x: "third" }),
+      ]);
+
+      expect(collector.records[0]!.get("before_val")).toBe("none");
+      expect(collector.records[1]!.get("before_val")).toBe("first");
+      expect(collector.records[2]!.get("before_val")).toBe("second");
+    });
+
+    test("B array ordering: most recent first", () => {
+      const { op, collector } = makeOp([
+        "-B", "3",
+        "{{bvals}} = B.map(b => b.get('x')).join(',')",
+      ]);
+      feedRecords(op, [
+        new Record({ x: 1 }),
+        new Record({ x: 2 }),
+        new Record({ x: 3 }),
+        new Record({ x: 4 }),
+        new Record({ x: 5 }),
+      ]);
+
+      // B[0] is the most recent previous record (unshift order)
+      expect(collector.records[4]!.get("bvals")).toBe("4,3,2");
+    });
   });
 
-  test("push_output sends records directly to output", () => {
-    const { op, collector } = makeOp([
-      "push_output({x: r.get('a') * 10}); push_output({x: r.get('a') * 100})",
-    ]);
-    feedRecords(op, [
-      new Record({ a: 2 }),
-      new Record({ a: 3 }),
-    ]);
+  describe("pre-snippet", () => {
+    test("runs before any records", () => {
+      const { op, collector } = makeOp([
+        "--pre-snippet", "state.count = 0",
+        "state.count++; {{idx}} = state.count",
+      ]);
+      feedRecords(op, [
+        new Record({ a: 1 }),
+        new Record({ a: 2 }),
+        new Record({ a: 3 }),
+      ]);
 
-    expect(collector.records.length).toBe(4);
-    expect(collector.records[0]!.get("x")).toBe(20);
-    expect(collector.records[1]!.get("x")).toBe(200);
-    expect(collector.records[2]!.get("x")).toBe(30);
-    expect(collector.records[3]!.get("x")).toBe(300);
+      expect(collector.records.length).toBe(3);
+      expect(collector.records[0]!.get("idx")).toBe(1);
+      expect(collector.records[1]!.get("idx")).toBe(2);
+      expect(collector.records[2]!.get("idx")).toBe(3);
+    });
+
+    test("pre-snippet with push_output", () => {
+      const { op, collector } = makeOp([
+        "--pre-snippet", "push_output({header: true})",
+        "r",
+      ]);
+      feedRecords(op, [
+        new Record({ a: 1 }),
+      ]);
+
+      expect(collector.records.length).toBe(2);
+      expect(collector.records[0]!.get("header")).toBe(true);
+      expect(collector.records[1]!.get("a")).toBe(1);
+    });
+
+    test("pre-snippet variable scoping persists to main snippet", () => {
+      const { op, collector } = makeOp([
+        "--pre-snippet", "state.prefix = 'hello'",
+        "{{msg}} = state.prefix + '_' + {{a}}",
+      ]);
+      feedRecords(op, [
+        new Record({ a: "world" }),
+      ]);
+
+      expect(collector.records[0]!.get("msg")).toBe("hello_world");
+    });
+
+    test("pre-snippet runs even with empty input", () => {
+      const { op, collector } = makeOp([
+        "--pre-snippet", "push_output({init: true})",
+        "r",
+      ]);
+      feedRecords(op, []);
+
+      expect(collector.records.length).toBe(1);
+      expect(collector.records[0]!.get("init")).toBe(true);
+    });
   });
 
-  test("push_input re-injects records into the input stream", () => {
-    // Use push_input to duplicate a record with a marker, but only once
-    const { op, collector } = makeOp([
-      "if (!r.get('dup')) { push_input({a: r.get('a'), dup: true}) }",
-    ]);
-    feedRecords(op, [
-      new Record({ a: 1 }),
-    ]);
+  describe("post-snippet", () => {
+    test("runs after all records", () => {
+      const { op, collector } = makeOp([
+        "--post-snippet", "push_output({done: true})",
+        "r.set('seen', true)",
+      ]);
+      feedRecords(op, [
+        new Record({ a: 1 }),
+      ]);
 
-    // The original is suppressed (push_input sets suppressR), then the
-    // duplicated record {a:1, dup:true} is re-processed and output normally
-    expect(collector.records.length).toBe(1);
-    expect(collector.records[0]!.get("a")).toBe(1);
-    expect(collector.records[0]!.get("dup")).toBe(true);
+      expect(collector.records.length).toBe(2);
+      expect(collector.records[0]!.get("seen")).toBe(true);
+      expect(collector.records[1]!.get("done")).toBe(true);
+    });
+
+    test("post-snippet can access state from main snippet", () => {
+      const { op, collector } = makeOp([
+        "--post-snippet", "push_output({total: state.sum})",
+        "state.sum = (state.sum || 0) + {{x}}",
+      ]);
+      feedRecords(op, [
+        new Record({ x: 10 }),
+        new Record({ x: 20 }),
+        new Record({ x: 30 }),
+      ]);
+
+      expect(collector.records.length).toBe(4);
+      expect(collector.records[3]!.get("total")).toBe(60);
+    });
+
+    test("post-snippet with push_input", () => {
+      const { op, collector } = makeOp([
+        "--post-snippet", "push_input({injected: true})",
+        "{{processed}} = true",
+      ]);
+      feedRecords(op, [
+        new Record({ a: 1 }),
+      ]);
+
+      // Original record + injected record processed through main snippet
+      expect(collector.records.length).toBe(2);
+      expect(collector.records[0]!.get("processed")).toBe(true);
+      expect(collector.records[1]!.get("injected")).toBe(true);
+      expect(collector.records[1]!.get("processed")).toBe(true);
+    });
+
+    test("post-snippet runs even with empty input", () => {
+      const { op, collector } = makeOp([
+        "--post-snippet", "push_output({footer: true})",
+        "r",
+      ]);
+      feedRecords(op, []);
+
+      expect(collector.records.length).toBe(1);
+      expect(collector.records[0]!.get("footer")).toBe(true);
+    });
+
+    test("post-snippet can emit multiple records", () => {
+      const { op, collector } = makeOp([
+        "--post-snippet", "push_output({s: 1}); push_output({s: 2}); push_output({s: 3})",
+        "r",
+      ]);
+      feedRecords(op, [
+        new Record({ a: 1 }),
+      ]);
+
+      expect(collector.records.length).toBe(4);
+      expect(collector.records[1]!.get("s")).toBe(1);
+      expect(collector.records[2]!.get("s")).toBe(2);
+      expect(collector.records[3]!.get("s")).toBe(3);
+    });
   });
 
-  test("push_output suppresses default record output", () => {
-    const { op, collector } = makeOp(["push_output({out: true})"]);
-    feedRecords(op, [
-      new Record({ a: 1 }),
-    ]);
+  describe("pre and post snippets combined", () => {
+    test("pre-snippet initializes, post-snippet summarizes", () => {
+      const { op, collector } = makeOp([
+        "--pre-snippet", "state.sum = 0",
+        "--post-snippet", "push_output({sum: state.sum})",
+        "state.sum += {{x}}",
+      ]);
+      feedRecords(op, [
+        new Record({ x: 1 }),
+        new Record({ x: 2 }),
+        new Record({ x: 3 }),
+      ]);
 
-    // Only the pushed record should appear, not the original
-    expect(collector.records.length).toBe(1);
-    expect(collector.records[0]!.get("out")).toBe(true);
+      // 3 records + 1 summary
+      expect(collector.records.length).toBe(4);
+      expect(collector.records[3]!.get("sum")).toBe(6);
+    });
+
+    test("pre and post with empty input", () => {
+      const { op, collector } = makeOp([
+        "--pre-snippet", "push_output({start: true})",
+        "--post-snippet", "push_output({end: true})",
+        "r",
+      ]);
+      feedRecords(op, []);
+
+      expect(collector.records.length).toBe(2);
+      expect(collector.records[0]!.get("start")).toBe(true);
+      expect(collector.records[1]!.get("end")).toBe(true);
+    });
   });
 
-  test("push_output works in post-snippet", () => {
-    const { op, collector } = makeOp([
-      "--post-snippet", "push_output({done: true})",
-      "r.set('seen', true)",
-    ]);
-    feedRecords(op, [
-      new Record({ a: 1 }),
-    ]);
+  describe("line counter", () => {
+    test("$line starts at 1", () => {
+      const { op, collector } = makeOp(["{{line}} = $line"]);
+      feedRecords(op, [
+        new Record({ a: 1 }),
+        new Record({ a: 2 }),
+        new Record({ a: 3 }),
+      ]);
 
-    expect(collector.records.length).toBe(2);
-    expect(collector.records[0]!.get("seen")).toBe(true);
-    expect(collector.records[1]!.get("done")).toBe(true);
+      expect(collector.records[0]!.get("line")).toBe(1);
+      expect(collector.records[1]!.get("line")).toBe(2);
+      expect(collector.records[2]!.get("line")).toBe(3);
+    });
+
+    test("$line resets after pre-snippet", () => {
+      const { op, collector } = makeOp([
+        "--pre-snippet", "state.x = 1",
+        "{{line}} = $line",
+      ]);
+      feedRecords(op, [
+        new Record({ a: 1 }),
+        new Record({ a: 2 }),
+      ]);
+
+      // Pre-snippet increments line, but resetLine() is called after
+      expect(collector.records[0]!.get("line")).toBe(1);
+      expect(collector.records[1]!.get("line")).toBe(2);
+    });
+  });
+
+  describe("edge cases", () => {
+    test("record with nested fields", () => {
+      const { op, collector } = makeOp(["{{a/b}} = {{x}} + 1"]);
+      feedRecords(op, [
+        new Record({ x: 5, a: { b: 0 } }),
+      ]);
+
+      // KeySpec a/b navigates into nested object
+      const data = collector.records[0]!.dataRef() as { a: { b: number } };
+      expect(data.a.b).toBe(6);
+    });
+
+    test("modifying record doesn't affect original", () => {
+      const original = new Record({ x: 1 });
+      const { op, collector } = makeOp(["{{y}} = {{x}} + 1"]);
+      feedRecords(op, [original]);
+
+      expect(collector.records[0]!.get("y")).toBe(2);
+      // xform modifies in place, so original IS modified
+      expect(original.get("y")).toBe(2);
+    });
+
+    test("undefined field access", () => {
+      const { op, collector } = makeOp(["{{result}} = {{missing}} || 'default'"]);
+      feedRecords(op, [
+        new Record({ a: 1 }),
+      ]);
+
+      expect(collector.records[0]!.get("result")).toBe("default");
+    });
+
+    test("multiple semicolons in expression", () => {
+      const { op, collector } = makeOp(["{{x}} = 1; {{y}} = 2; {{z}} = 3"]);
+      feedRecords(op, [
+        new Record({}),
+      ]);
+
+      expect(collector.records[0]!.get("x")).toBe(1);
+      expect(collector.records[0]!.get("y")).toBe(2);
+      expect(collector.records[0]!.get("z")).toBe(3);
+    });
+
+    test("record method access (r.get/r.set)", () => {
+      const { op, collector } = makeOp(["r.set('b', r.get('a') * 2)"]);
+      feedRecords(op, [
+        new Record({ a: 5 }),
+      ]);
+
+      expect(collector.records[0]!.get("b")).toBe(10);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Fix eval chomp behavior, multiplex bucket key merging, collate --cube flag
- Refactor chain from buffered spawnSync to streaming Bun.spawn pipes
- Add --shell to generate, multi-DB to todb, --woothee to fromapache
- Add comprehensive packet parsing to fromtcpdump (MAC, IP, TCP, UDP, DNS, ARP)
- Add multi-unit durations and chrono-node to normalizetime
- Add default UID conversion to fromps, deaggregator registry to decollate
- Add Ord2Bivariate/Ord2Univariate statistical aggregators
- Add ~190 new tests across 17 operations (1886 pass, 0 fail)

## Test plan
- [x] `bun test` — 1886 pass, 12 skip, 0 fail
- [x] `bunx oxlint` — 0 errors (2 pre-existing warnings)
- [x] `tsc --noEmit` — clean
- [x] `check-no-private` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)